### PR TITLE
Standard API reference

### DIFF
--- a/reference/runtime/api-reference.md
+++ b/reference/runtime/api-reference.md
@@ -2,32 +2,15 @@
 
 The Workers Runtime provides the following standardized APIs for use by scripts running at the Edge.
 
-It is important to note that due to [how workers are executed](TODO: link to "How Workers Work"), some APIs are only available inside a request context. A request context is active during a [Fetch Event](TODO: hashlink) callback, and, if you pass a Response promise to FetchEvent.respondWith(), any asynchronous tasks which run before the Response promise has settled. Any attempt to use such APIs during script startup will throw an exception.
-
-For example:
-
-``` javascript
-const promise = fetch("https://example.com/")       // ERROR
-
-addEventListener("fetch", event => {
-  event.respondWith(fetch("https://example.com/"))  // OK
-})
-```
-
-This code snippet will throw during script startup, and the `"fetch"` event
-listener will never be registered.
-
-Also, some APIs are only available in production, and not in the playground. The playgrounds are the Workers instances which power cloudflareworkers.com and the Workers editor UI on dash.cloudflare.com.
+Methods highlighted in orange are only implemented in the scope of a [request context](TODO: link to request context).
 
 ## JavaScript Standards
 
-All of the standard built-in objects supported by the current [Google Chrome stable release](TODO: link to google chrome release notes) are supported, with a few notable exceptions:
+All of the [standard built-in objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference) supported by the current Google Chrome stable release are supported, with a few notable exceptions:
 
 * `eval()` is not allowed for security reasons.
 * `new Function` is not allowed for security reasons.
 * `Date.now()` returns the time of the last I/O; it does not advance during code execution.
-
-[Go to the docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference)
 
 ## Service Worker API
 
@@ -64,11 +47,10 @@ The URL API supports urls conforming to http and https schemes.
 
 * TODO: expand list of supported features
 
-## Stream API
+## Streams API
 
-The [Request]() object implements [WritableStream]().
-
-The [Response]() object implements [ReadableStream]().
+* [WritableStream]()
+* [ReadableStream]()
 
 An object implementing both WritableStream and ReadableStream can be instantiated using the zero-argument constructor [TransformStream()]()
 

--- a/reference/runtime/request-context.md
+++ b/reference/runtime/request-context.md
@@ -1,0 +1,17 @@
+# The Request Context
+
+It is important to note that due to [how workers are executed](TODO: link to "How Workers Work"), some APIs are only available inside a request context. A request context is active during a [Fetch Event](TODO: hashlink) callback, and, if you pass a Response promise to FetchEvent.respondWith(), any asynchronous tasks which run before the Response promise has settled. Any attempt to use such APIs during script startup will throw an exception.
+
+For example:
+
+```javascript
+const promise = fetch("https://example.com/")       // ERROR
+
+addEventListener("fetch", event => {
+  event.respondWith(fetch("https://example.com/"))  // OK
+})
+```
+
+This code snippet will throw during script startup, and the `"fetch"` event
+listener will never be registered.
+


### PR DESCRIPTION
solves #11 

This is nearly a wholesale dump of the information found here: https://developers.cloudflare.com/workers/reference/. A couple of thoughts:

I moved the callout of the FetchEvent scope and the Preview differences to the top; they're brief enough that I think it is worth calling out early, especially if we are not going to have debugging or troubleshooting docs for launch. That being said, I'm open to suggestions around how exactly to tag those interfaces that are affected by those differences; the footnote-style callouts in the existing documentation feel kind of awkward? Maybe this whole thing should be more tabular? I'm going to leave this PR to soak for a bit.