### PR TITLE
Add article about best practices modifying requests/responses

### DIFF
--- a/content/reference/runtime/apis/fetch.md
+++ b/content/reference/runtime/apis/fetch.md
@@ -5,7 +5,7 @@ weight: 2
 
 ## Overview
 
-The [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) provides an interface for asyncronously fetching resources by providing a definition of a request and response. You will frequently find yourself interacting with request objects included as part of a [FetchEvent](../fetch-event), making your own requests using the global `fetch` method, and constructing your own responses.
+The [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) provides an interface for asyncronously fetching resources by providing a definition of a request and response. You will frequently find yourself interacting with request objects included as part of a [FetchEvent](/reference/runtime/apis/fetch-event), making your own requests using the global `fetch` method, and constructing your own responses.
 
 ## Global
 
@@ -31,27 +31,29 @@ new Request(input [, init])
 
 #### Constructor Parameters
 
-* `input`: Either a USVString that contains the URL or an existing `Request` object. Note that the `url` property is immutable, so when [modifying a request](TODO: link to 'modifying requests/responses') and changing the URL, you must pass the new URL in this parameter.
+* `input`: Either a USVString that contains the URL or an existing `Request` object. Note that the `url` property is immutable, so when [modifying a request](/reference/workers-concepts/modifying-requests) and changing the URL, you must pass the new URL in this parameter.
 
 * `init` (optional): An options object that contains custom settings to apply to the request. Valid options are:
 	* `method`: The request method, such as `GET` or `POST`
 	* `headers`: A [Headers](#headers) object
-	* `body`: Any text to add to the request: TODO: Enumerate possible types.
+	* `body`: Any text to add to the request
 	**Note:** Requests using the `GET` or `HEAD` methods cannot have a body.
-	* `redirect`: The redirect mode to use: `follow`, `error`, or `manual`. TODO: what is the default?
+	* `redirect`: The redirect mode to use: `follow`, `error`, or `manual`. Defaults to `manual`.
 
 		* `follow`
 		* `error`
 		* `manual`
 
-All properties of a `Request` object are read only. To [modify a request](TODO: link to modifying a request), you must create a new `Request` object and pass the options to modify to its [constructor](#Constructor).
+### Properties
 
-* `body`: A simple getter that exposes a [`ReadableStream`](../streams) of the contents.
+All properties of a `Request` object are read only. To [modify a request](/reference/workers-concepts/modifying-requests), you must create a new `Request` object and pass the options to modify to its [constructor](#Constructor).
+
+* `body`: A simple getter that exposes a [`ReadableStream`](/reference/runtime/apis/streams) of the contents.
 * `bodyUsed`: A Boolean that declares if the body has been used in a response.
 * `cf`: An object that contains data provided by Cloudflare (see `request.cf` below).
 * `headers`: Contain the associated [`Headers`](#headers) object for the request.
 * `method`: The request method, such as `GET` or `POST`, associated with the request.
-* `redirect`: The redirect mode to use: `follow`, `error`, or `manual`. TODO: what is the default?
+* `redirect`: The redirect mode to use: `follow`, `error`, or `manual`. Default to `manual`.
 * `url`: Contains the URL of the request.
 
 #### The `cf` Object

--- a/content/reference/workers-concepts/modifying-requests.md
+++ b/content/reference/workers-concepts/modifying-requests.md
@@ -23,7 +23,7 @@ addEventListener("fetch", event => {
 })
 ```
 
-### Changing the Redirect Mode
+### Method 1: Overwrite Specific Properties
 
 The `redirect` property is just one of the many options available in the `RequestInit` passed to the `Request()` constructor. In this case, we can pass in the original request as the first argument to the constructor, and the partial RequestInit object containing the desired redirect mode. This acts as a merge, preserving all parts of the original request except the part we want to update.
 
@@ -32,6 +32,23 @@ The `redirect` property is just one of the many options available in the `Reques
 // with only the `redirect` property overwritten.
 request = new Request(request, { redirect: "follow" })
 ```
+
+This method is the most appropriate for most properties, especially with properties like `method` which are immutable for a constructed request.
+
+#### Modifying a Request
+
+ When modifying a [request](/reference/runtime/apis/fetch#request), use this method for the following property updates:
+
+* `method`
+* `body`
+* `redirect`
+
+#### Modifying a Response
+
+ When modifying a [response](/reference/runtime/apis/fetch#response), use this method for the following property updates:
+
+* `status`
+* `statusText`
 
 ### Changing the URL
 
@@ -57,7 +74,9 @@ url.hostname = "example.com"
 request = new Request(url, request)
 ```
 
-### Adding a Header
+This works due to the fact that, while a Request object happens to contain all of the attributes of the options object that is passed to the constructor, the options object does not include the URL. That can only be set using the first argument to the constructor.
+
+### Modifying Specific Headers
 
 Because the `RequestInit` object only merges at the top level, passing a `headers` object in this way will overwrite all existing headers, rather than merging them as you might want to do. To that end, you can either clone the headers and add to the resulting Headers object, then pass it in to `RequestInit`, or use the instance-level methods on the Headers class to make the modifications directly on the request.
 
@@ -71,3 +90,17 @@ let headers = event.request.headers
 headers.add("X-Example", "foo")
 request = new Request(request, { headers })
 ```
+
+#### Modifying a FetchEvent's request headers
+
+The `request` object that comes as part of a [FetchEvent](/reference/runtime/apis/fetch-event) is a little bit different from other request objects, in that it has immutable headers. Authors need to clone this request before modifying headers:
+
+```javascript
+addEventListener("fetch", event => {
+  let newRequest = new Request(event.request)
+  newRequest.headers.add("X-Example", "foo")
+  
+  // do something with your newRequest
+})
+```
+


### PR DESCRIPTION
Not part of originally scoped work, but a common mistake users encounter.