### PR TITLE
Add section about API Gateway errors to REST API reference

### DIFF
--- a/content/reference/tooling/api/requests.md
+++ b/content/reference/tooling/api/requests.md
@@ -3,6 +3,8 @@ title: Making Requests
 weight: 1
 ---
 
+## Auth Headers
+
 All requests to the Cloudflare Workers REST API must
 
 - be sent over HTTPS
@@ -27,7 +29,58 @@ All Cloudflare APIs respond with a JSON object that has the following shape:
 - `code`: A Number representing the error from the API
 - `message`: A human readable String providing additional information about the error.
 
-## Cloudflare API Gateway
+## Authentication/Authorization Errors
 
-TODO: some errors can come back from the API gateway (specifically issues with account/zone). Link to documentation about these errors.
+### No route for that URI
 
+All API endpoint paths are prefixed with either `/accounts/:account_id/` or `/zones/:zone_id`. These values are used by Cloudflare's API gateway to authenticate requests before forwarding on to the Workers API. If you receive a response that looks like the following, check your configuration: it is likely you have mis-formatted either your ZoneID or your AccountID:
+
+```json
+{
+    "errors": [
+        {
+            "code": 7003,
+            "message": "Could not route to /zones/notazone/workers/script/bindings, perhaps your object identifier is invalid?"
+        },
+        {
+            "code": 7000,
+            "message": "No route for that URI"
+        }
+    ],
+    "messages": [],
+    "result": null,
+    "success": false
+}
+```
+
+### Authentication error
+
+If you fail to match the AccountID or ZoneID and your authorization headers, you will receive an error that looks like the following:
+
+```json
+{
+    "errors": [
+        {
+            "code": 10000,
+            "message": "Authentication error"
+        }
+    ],
+    "success": false
+}
+```
+
+### Missing Auth Headers
+
+If you fail to include the appropriate [Authentication headers](#auth-headers), you will receive an error that looks like the following:
+
+```json
+{
+    "errors": [
+        {
+            "code": 9106,
+            "message": "Missing X-Auth-Key, X-Auth-Email or Authorization headers"
+        }
+    ],
+    "success": false
+}
+```


### PR DESCRIPTION
bc of the way our API is structured, this has been a complaint in the past. even though the api gateway team appears to have updated the error message to return the URL in question as part of the error message, I think it's important to document this. Looking for feedback on wording.