### PR TITLE
"Deploying To Your Domain" in quickstart/_index

### DIFF
--- a/content/quickstart/_index.md
+++ b/content/quickstart/_index.md
@@ -6,4 +6,5 @@ weight: 1
 
 - [Write Code](/quickstart/write-code)
 - [Installing the CLI](/quickstart/cli-setup)
+- [Deploying To Your Domain](/quickstart/deploying-to-your-domain)
 - [Finding Your Cloudflare API Keys](/quickstart/api-keys)


### PR DESCRIPTION
#157 added the "Deploying To Your Domain" page to the quickstart section, so we could easily delineate between zoned/zoneless deploys (thanks to dubs for the suggestion here) – I forgot to update `quickstart/_index.md` with the new page, so doing that here