### PR TITLE
Add cf headers

### DIFF
--- a/content/reference/runtime/apis/fetch.md
+++ b/content/reference/runtime/apis/fetch.md
@@ -111,7 +111,6 @@ Cloudflare features you can set on outbound requests:
 <!-- * cache_api?  -->
 
 A Workers script runs after Cloudflare security features, but before everything else. Therefore, a Workers script cannot affect the operation of security features (since they already finished), but it can affect other features, like Polish or ScrapeShield, or how Cloudflare caches the response.
-operation of security features (since they already finished), but it can affect other features, like Polish or ScrapeShield, or how Cloudflare caches the response.
 
 Updating the `cf` object is similar to [modifying a request](/reference/workers-concepts/modifying-requests/). You can add the `cf` object to a `Request` by passing a custom headers object to [`fetch`](/reference/runtime/apis/fetch/). 
 ```javascript


### PR DESCRIPTION
fixes #70 

While working on #70 on I found we missed a bunch on `request.cf`
* Original content https://developers.cloudflare.com/workers/reference/cloudflare-features/
* source code for request props added https://bitbucket.cfdata.org/projects/NGINX/repos/lua-cdn/browse/edge_worker/outgoing.lua#132

I would love to move `Request` and `Response` to their own sections since this is getting long and hard to find, but Alewis may kill me for out of scope at this stage.