### PR TITLE
Disable search box

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -11,15 +11,6 @@
 
 <div id="sidebar-open-backdrop"></div>
 <nav id="sidebar">
-  <div class="search-container">
-    <input
-      class="search-input"
-      type="text"
-      id="docsearch-input"
-      placeholder="Search the docs..."
-    />
-  </div>
-
   {{ $currentNode := . }}
   <div class="highlightable">
     <ul class="topics">
@@ -110,11 +101,3 @@
   {{ end }}
  {{ end }}
 {{ end }}
-
-<script type="text/javascript">
-  docsearch({
-    apiKey: '4c1a7e1b6289032a8e8fd1dbbae112a3',
-    indexName: 'cloudflare',
-    inputSelector: '#docsearch-input'
-  });
-</script>


### PR DESCRIPTION

<img width="397" alt="Screen Shot 2019-05-31 at 12 25 42 PM" src="https://user-images.githubusercontent.com/922353/58723280-4a3c1100-839f-11e9-89a5-85c1ecbd3553.png">


We don't have access to the docsearch account that this project uses, so for now, I'm disabling the search box. It'll be re-enabled when the work in #196 is completed.

Note that this PR adds the `sidebar.html` partial from `hugo-cloudflare-docs`, meaning that we'll own our sidebar config - this will give us more control over how pages are formatted there - woo!