### PR TITLE
Update limits to address free tier, rate limits

### DIFF
--- a/content/reference/runtime/limits.md
+++ b/content/reference/runtime/limits.md
@@ -26,14 +26,12 @@ Accounts using the Workers free tier are limited to a maximum of 100,000 request
 
 ## CPU/Execution Time Limit
 
-Most Workers requests consume less than a millisecond. It’s rare to find a normally operating Workers script that exceeds the CPU time limit.
-
 | Plan                      | CPU   |
 | ------------------------- | ----- |
 | Free                      | 10ms  |
-| Unlimited (Paid)          | 10ms+ |
+| Unlimited (Paid)          | 50ms  |
 
-The 10ms the Free plan allows is enough runtime for most use cases, including application hosting. If you expect to exceed these limits, Cloudflare is happy to discuss options.
+Most Workers requests consume less than a millisecond. It’s rare to find a normally operating Workers script that exceeds the CPU time limit. The 10ms the Free plan allows is enough runtime for most use cases, including application hosting.
 
 There is no limit on the real runtime for a Workers script. As long as the client that sent the request remains connected, the Workers script can continue processing, making subrequests, and setting timeouts on behalf of that request. When the client disconnects, all tasks associated with that client request are canceled. You can use [`event.waitUntil()`](/reference/runtime/apis/fetch-event/) to delay cancellation for another 30 seconds or until the promise passed to `waitUntil()` completes.
 


### PR DESCRIPTION
in addition to the changes in this PR, I want to confirm the CPU limits table; iirc there's messaging there, but the problem with having a free tier AND a free cloudflare plan is that the messaging is wonky. open to suggestions.

closes #108 