### PR TITLE
Serve non-text assets from GCS

### DIFF
--- a/worker/worker/worker.js
+++ b/worker/worker/worker.js
@@ -16,6 +16,9 @@ async function handleRequest(request) {
 
       var path = normalize_path(pathname)
 
+      var contentType = determine_content_type(path)
+
+      let body
       if (contentType.startsWith("text")) {
         body = await STATIC_CONTENT.get(path)
       } else {
@@ -99,6 +102,8 @@ function determine_content_type(path) {
     return "image/jpeg"
   } else if (path.endsWith("mp4")) {
     return "video/mp4"
+  } else if (path.endsWith("gif")) {
+    return "image/gif"
   } else {
     return "text/plain"
   }


### PR DESCRIPTION
Any kind of assets that _aren't_ text (screenshots, GIFs, etc) aren't working with the current worker deploy setup. This PR checks on `content-type` and retrieves the asset from a public GCS bucket. This is absolutely a temporary fix and makes a hard dependency on keeping that GCS bucket up to date 😢 

I've tested this in a [playground](https://cloudflareworkers.com/#ba77ea33b862b6816719dfba4780b8f0:https://workers.cloudflare.com/docs/tutorials/build-an-application/) to make sure that loading assets from the bucket works correctly. As long as we feel good about everything else loading out of KV, I feel good w/ this update :)

cc #192