### PR TITLE
Serve media files from KV instead of GCS

### DIFF
--- a/worker/worker/worker.js
+++ b/worker/worker/worker.js
@@ -22,15 +22,7 @@ async function handleRequest(request) {
 
       var contentType = determine_content_type(path)
 
-      let body
-      if (contentType.startsWith("text")) {
-        body = await STATIC_CONTENT.get(path)
-      } else {
-        const gcsResp = await fetch(
-          `https://storage.googleapis.com/cloudflare-docs-assets/public/${path}`,
-        )
-        body = gcsResp.body
-      }
+      let body = await STATIC_CONTENT.get(path, "arrayBuffer")
 
       let res = new Response(body, {status: 200})
       res.headers.set("Content-type", contentType)


### PR DESCRIPTION
This commit un-does #200.

The issue was that:
https://workers.cloudflare.com/docs/reference/storage/reading-data/#types

"text" (default)
A string.

Strings, however, have an encoding. We don't want something with an
encoding, we want raw bytes. That's what "arrayBuffer" is for. By using
it, we can remove the fallback, and everything works.

Fixes #201