### PR TITLE
Add speedtest worker template

### DIFF
--- a/data/featured/speedtest_worker.toml
+++ b/data/featured/speedtest_worker.toml
@@ -1,0 +1,3 @@
+name = "Speedtest-Worker"
+description = "Worker for measuring download / upload connection speed from the client side, using the Performance Timing API"
+repository_url = "https://github.com/cloudflare/worker-speedtest-template"


### PR DESCRIPTION
This adds a new template in the _Featured Projects_ section, for a connection speed test. It's the worker code that powers https://speed.cloudflare.com.