### PR TITLE
Add emscripten template

### DIFF
--- a/data/templates/emscripten.toml
+++ b/data/templates/emscripten.toml
@@ -1,5 +1,5 @@
 name = "Emscripten + Wasm Image Resizer"
 description = "Image Resizer in C compiled to Wasm with Emscripten"
 repository_url = "https://github.com/cloudflare/worker-emscripten-template"
-demo_url = "https://cloudflareworkers.com/#ddb7fa39e09cdf734180c5d083ddb390:https://placehold.co/1200x800.jpg?width=100"
+demo_url = "https://cloudflareworkers.com/#ddb7fa39e09cdf734180c5d083ddb390:http://placehold.jp/1200x800.png?width=100"
 weight = 3


### PR DESCRIPTION
Needs before merge:
cleanup on the worker JS code side, and subsequent update of demo url
creation of the repo for it in the cloudflare organization, it currently lives on ashley's acct
https://github.com/ashleygwilliams/worker-emscripten-template/tree/malonso-imageresizer

Has needs review label for:
review of name and description