### PR TITLE
Add community contributed Sentry template

### DIFF
--- a/data/templates/sentry.toml
+++ b/data/templates/sentry.toml
@@ -1,0 +1,3 @@
+name = "sentry"
+description = "Log exceptions and errors in your Workers application to Sentry.io, an error tracking tool"
+repository_url = "https://github.com/bustle/cf-sentry"


### PR DESCRIPTION
Bustle and [Michael Hart](https://twitter.com/hichaelmart) have written a Sentry template (https://github.com/bustle/cf-sentry) - a lot of people ask about this, so let's list it in the Template Gallery! I've confirmed that the project works by generating and deploying with my own Sentry config.
