### PR TITLE
Connor/country code

### DIFF
--- a/data/snippets/country_code.toml
+++ b/data/snippets/country_code.toml
@@ -1,7 +1,6 @@
 name = "Country Code"
 description = "Redirect a response based on the country code of the visitor"
 code = """
-// This snippet isn't supported in the previewer
 async function handleRequest(request) {
   return redirect(request, 'subdomain')
 }
@@ -13,6 +12,7 @@ addEventListener('fetch', event => {
  * @param {Request} request
  */
 function redirect(request) {
+  The `cf-ipcountry` header is not supported in the previewer
   const country = request.headers.get('cf-ipcountry')
   const url = countryMap[country]
   return Response.redirect(url)


### PR DESCRIPTION
`request.headers.get(cf-countryip)` is not supported in cloudflareworkers.com's editor. It is only supported on production workers. Perhaps we could fix that to allow a default of US to always be returned on cloudflareworkers.com if we ask the workers team kindly? Regardless, I put N/A in the spot for the meantime. Otherwise, we just link to a broken worker.

Also, the code causes recursion in the previewer - ie, you'll get us.web.com, then us.us.web.com, then us.us.us.us.web.com.

What is our future protocol for snippets that break in the previewer? code_url seems to be a required field - the snippet won't load in the docs unless we put something there. Maybe we should remove that requirement?

https://cloudflareworkers.com/#77704b072dbd6f1cd60a151644dd136b:https://tutorial.cloudflareworkers.com


