### PR TITLE
Add TLS Version snippet.

### DIFF
--- a/data/snippets/tls_version.toml
+++ b/data/snippets/tls_version.toml
@@ -1,21 +1,23 @@
-name = "Get TLS Version"
-description = "Inspects the incoming request's TLS version, then returns the value in a response header"
+name = "Block on TLS Version"
+description = "Inspects the incoming request's TLS version and blocks if under TLSv1.2."
 code = """
 async function handleRequest(request) {
   try {
     let tlsVersion = request.cf.tlsVersion
-    const response = await fetch(request)
-    let newHeaders = new Headers(response.headers)
-    newHeaders.append('X-TLS-Version', tlsVersion)
-    return new Response(response, {
-      headers: newHeaders,
-    })
+    // Allow only TLS versions 1.2 and 1.3
+    if (tlsVersion != 'TLSv1.2' && tlsVersion != 'TLSv1.3') {
+      return new Response('Please use TLS version 1.2 or higher.', {
+        status: 403,
+      })
+    }
+    return fetch(request)
   } catch (err) {
     console.error(
       'request.cf does not exist in the previewer, only in production',
     )
-    console.error(err)
-    return fetch(request)
+    return new Response('Error in workers script' + err.message, {
+      status: 500,
+    })
   }
 }
 addEventListener('fetch', event => {


### PR DESCRIPTION
Adding the tls version snippet. I made some slight edits and tested it in production before making the pr.

This is another snippet that doesn't work in the previewer. Unlike the other pr's, I left the preview option in the toml blank instead of putting 'N/A'.

I suppose this can wait until the docs are updated