### PR TITLE
Fix template links

### DIFF
--- a/data/featured/cloud_storage.toml
+++ b/data/featured/cloud_storage.toml
@@ -3,4 +3,4 @@ description = "Serve private AWS bucket files from a Worker script"
 repository_url = "https://github.com/conzorkingkong/cloud-storage"
 
 tags = ['Middleware']
-tutorial="featured_boilerplates/cloud_storage"
+share="/templates/featured_boilerplates/cloud_storage"

--- a/data/snippet/ab_testing.toml
+++ b/data/snippet/ab_testing.toml
@@ -26,4 +26,4 @@ addEventListener('fetch', event => {
 })
 '''
 demo_url = "https://cloudflareworkers.com/#12a2962014e1324e3a416a5a76e1f81f:https://tutorial.cloudflareworkers.com"
-share = "snippets/ab_testing"
+share = "/templates/snippets/ab_testing"

--- a/data/snippet/aggregate_requests.toml
+++ b/data/snippet/aggregate_requests.toml
@@ -44,4 +44,4 @@ const type = 'application/json;charset=UTF-8'
 '''
 demo_url = "https://cloudflareworkers.com/#eaaa52283784c21aec989c64b9db32d3:https://example.com"
 tags = ['Middleware']
-share = "snippets/aggregate_requests"
+share = "/templates/snippets/aggregate_requests"

--- a/data/snippet/alter_headers.toml
+++ b/data/snippet/alter_headers.toml
@@ -17,4 +17,4 @@ addEventListener('fetch', event => {
 })
 '''
 demo_url = "https://cloudflareworkers.com/#5386d315ec8c899370e8e5d00cf88939:https://tutorial.cloudflareworkers.com"
-share = "snippets/alter_headers"
+share = "/templates/snippets/alter_headers"

--- a/data/snippet/conditional_response.toml
+++ b/data/snippet/conditional_response.toml
@@ -49,3 +49,4 @@ addEventListener('fetch', event => {
 """
 demo_url="https://cloudflareworkers.com/#cec6695f67232bc76e3f396fcb2d5cc7:https://nope.mywebsite.com/"
 tags=['Enterprise']
+share = "/templates/snippets/conditional_response"


### PR DESCRIPTION
Some links to templates were concatenating the path which made it broken
![image](https://user-images.githubusercontent.com/7578652/65085000-9ae97100-d972-11e9-89b9-96822c23013f.png)

(Note these individual pages are far from ideal but a temporary workaround for sharing templates)