### PR TITLE
redirect /workers/docs to /workers

### DIFF
--- a/workers-site/data/newDocs.js
+++ b/workers-site/data/newDocs.js
@@ -39,4 +39,8 @@ export const newDocsMap = new Map([
   ['/reference/storage/overview/writing-data', '/reference/storage/writing-data'],
 
   ['/tutorials/build-a-rustwasm-function', '/templates/boilerplates/rustwasm'],
+
+  // This is a remnant of some buggy workers.cloudflare.com code,
+  // we should explicitly handle this and send them to the right place
+  ['/workers/docs', '/workers'],
 ])


### PR DESCRIPTION
this weird url is a remnant of some buggy workers.cloudflare.com code, we should explictly handle it and send users to the right place