### PR TITLE
Add new badge support

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -62,6 +62,10 @@
        <a href="{{ .RelPermalink}}">
          <span>{{safeHTML .Params.Pre}}{{.Title}}{{safeHTML .Params.Post}}</span>
 
+         {{ if .Params.new }}
+           <span class="new-badge">NEW</span>
+         {{ end }}
+
          {{ $numberOfPages := (add (len .Pages) (len .Sections)) }}
          {{ if ne $numberOfPages 0 }}
 
@@ -106,6 +110,10 @@
        ">
          <a href="{{.RelPermalink}}">
          <span>{{safeHTML .Params.Pre}}{{.Title}}{{safeHTML .Params.Post}}</span>
+         {{ if .Params.new }}
+           <span class="new-badge">NEW</span>
+         {{ end }}
+
          </a></li>
       {{ end }}
    {{ end }}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -52,3 +52,13 @@ a.quick-start {
   opacity: 1;
   visibility: visible;
 }
+
+.new-badge {
+  background: #ebf8ff;
+  border-radius: 12px;
+  color: #3182ce;
+  font-size: 12px;
+  font-weight: bold;
+  margin-left: 3px;
+  padding: 3px 9px !important;
+}


### PR DESCRIPTION
This PR adds support for a "NEW" badge, which can be defined on posts and tutorials by adding `new: true` to the YAML frontmatter of a Markdown page.

<img width="287" alt="Screen Shot 2019-09-26 at 2 03 54 PM" src="https://user-images.githubusercontent.com/922353/65717445-f698b600-e066-11e9-9c9c-738d939897b1.png">
