### PR TITLE
Flesh out sites index content

### DIFF
--- a/content/sites/_index.md
+++ b/content/sites/_index.md
@@ -4,7 +4,7 @@ alwaysopen: true
 weight: 1
 ---
 
-Workers Sites enables developers to deploy static applications directly to Workers. Workers Sites is perfect for deploying applications built with frontend frameworks like [React](https://reactjs.org) and [Vue](https://vuejs.org/), as well as static site generators like [Hugo](https://gohugo.io/) and [Gatsby](https://gohugo.io/).
+Workers Sites enables developers to deploy static applications directly to Workers. Workers Sites is perfect for deploying applications built with frontend frameworks like [React](https://reactjs.org) and [Vue](https://vuejs.org/), as well as static site generators like [Hugo](https://gohugo.io/) and [Gatsby](https://www.gatsbyjs.org/).
 
 To use Workers Sites, you'll take one of three routes:
 


### PR DESCRIPTION
per @ashleygwilliams' suggestion, this PR adds some additional content at `/sites` to help set the stage for Workers Sites. we link to this page externally quite a few times, so we should flesh it out slightly more than the normal "index" pages that we have on the docs (`/tutorials`, `/reference`, etc)