### PR TITLE
removing repo link that is returning 404

### DIFF
--- a/content/tutorials/localize-a-website/_index.md
+++ b/content/tutorials/localize-a-website/_index.md
@@ -265,6 +265,6 @@ $ wrangler publish
 
 ## Resources
 
-In this tutorial, you built and published an i18n tool using `HTMLRewriter`. If you'd like to see the full source code for this application, visit the [repo on GitHub](https://github.com/signalnerve/i18n-example-workers).
+In this tutorial, you built and published an i18n tool using `HTMLRewriter`.
 
 If you want to get started building your own projects, check out the quick-start templates we've provided in our [Template Gallery](/templates).


### PR DESCRIPTION
@signalnerve `https://github.com/signalnerve/i18n-example-workers` returning 404 as there's nothing there. this commit removes the "see full source code..." line and reference to non-existent link.