### PR TITLE
Gabbi/wrangler include exclude

### DIFF
--- a/content/sites/_index.md
+++ b/content/sites/_index.md
@@ -21,4 +21,4 @@ If you have an existing project or static assets that you want to deploy with Wo
 
 If you already have an application deployed to Workers, this guide will show you how to use Workers Sites in your existing codebase, allowing you to deploy your entire application as a single Workers project.
 
-_Note: Worker Sites require the latest version of [Wrangler](https://github.com/cloudflare/wrangler) and the Workers [Unlimited plan](https://workers.cloudflare.com/sites#plans)._
+_Note: Workers Sites require the latest version of [Wrangler](https://github.com/cloudflare/wrangler) and the Workers [Unlimited plan](https://workers.cloudflare.com/sites#plans)._

--- a/content/sites/ignore-assets.md
+++ b/content/sites/ignore-assets.md
@@ -4,7 +4,7 @@ alwaysopen: true
 weight: 5
 ---
 
-Worker Sites require [Wrangler](https://github.com/cloudflare/wrangler) - make sure to be on the [latest version](/quickstart/#updating-the-cli) - and the Workers [Unlimited plan](https://workers.cloudflare.com/sites#plans).
+Workers Sites require [Wrangler](https://github.com/cloudflare/wrangler) - make sure to be on the [latest version](/quickstart/#updating-the-cli) - and the Workers [Unlimited plan](https://workers.cloudflare.com/sites#plans).
 
 There are cases where users may not want to upload certain static assets to their Workers Sites.
 In this case, Workers Sites can also be configured to ignore certain files or directories using logic 

--- a/content/sites/ignore-assets.md
+++ b/content/sites/ignore-assets.md
@@ -15,25 +15,29 @@ This means that we use gitignore semantics when declaring which directory entrie
 
 If you want to include only a certain set of files or directories in your `bucket`, you can add an `include` field to your
 `[site]` section of `wrangler.toml`:
+
 ```toml
 [site]
 bucket = "./public"
 entry-point = "workers-site" 
 include = ["included_dir"] # must be an array.
 ```
+
 Wrangler will only upload files or directories matching the patterns in the `include` array.
 
 ### Excluding files/directories
 
 If you want to exclude files or directories in your `bucket`, you can add an `exclude` field to your
 `[site]` section of `wrangler.toml`:
+
 ```toml
 [site]
 bucket = "./public"
 entry-point = "workers-site" 
 exclude = ["excluded_dir"] # must be an array.
 ```
-Wrangler will ignore files or directories matching the patterns in the `exclude` array when uploading assets to Wrangler.
+
+Wrangler will ignore files or directories matching the patterns in the `exclude` array when uploading assets to Workers KV.
 
 ### Include > Exclude
 

--- a/content/sites/ignore-assets.md
+++ b/content/sites/ignore-assets.md
@@ -1,0 +1,51 @@
+---
+title: Ignoring Subsets of Static Assets
+alwaysopen: true
+weight: 5
+---
+
+Worker Sites require [Wrangler](https://github.com/cloudflare/wrangler) - make sure to be on the [latest version](/quickstart/#updating-the-cli) - and the Workers [Unlimited plan](https://workers.cloudflare.com/sites#plans).
+
+There are cases where users may not want to upload certain static assets to their Workers Sites.
+In this case, Workers Sites can also be configured to ignore certain files or directories using logic 
+similar to [Cargo's optional include and exclude fields](https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields-optional).
+This means that we use gitignore semantics when declaring which directory entries to include or ignore in uploads.
+
+### Exclusively including files/directories
+
+If you want to include only a certain set of files or directories in your `bucket`, you can add an `include` field to your
+`[site]` section of `wrangler.toml`:
+```toml
+[site]
+bucket = "./public"
+entry-point = "workers-site" 
+include = ["included_dir"] # must be an array.
+```
+Wrangler will only upload files or directories matching the patterns in the `include` array.
+
+### Excluding files/directories
+
+If you want to exclude files or directories in your `bucket`, you can add an `exclude` field to your
+`[site]` section of `wrangler.toml`:
+```toml
+[site]
+bucket = "./public"
+entry-point = "workers-site" 
+exclude = ["excluded_dir"] # must be an array.
+```
+Wrangler will ignore files or directories matching the patterns in the `exclude` array when uploading assets to Wrangler.
+
+### Include > Exclude
+
+If you provide both `include` and `exclude` fields, the `include` field will be used and the `exclude` field will be ignored.
+
+### Default ignored entries
+
+Wrangler will always ignore
+- `node_modules`
+- Hidden files and directories
+- Symlinks
+
+### More about include/exclude patterns
+
+You can learn more about the standard patterns used for include and exclude in the [gitignore documentation](https://git-scm.com/docs/gitignore).

--- a/content/sites/reference.md
+++ b/content/sites/reference.md
@@ -1,7 +1,7 @@
 ---
 title: Wrangler Reference
 alwaysopen: true
-weight: 5
+weight: 6
 ---
 
 Worker Sites require the latest version of [Wrangler](https://github.com/cloudflare/wrangler) and the Workers [Unlimited plan](https://workers.cloudflare.com/sites#plans).
@@ -29,10 +29,12 @@ Worker Sites require the latest version of [Wrangler](https://github.com/cloudfl
 
 There are a few specific configuration settings for Workers Sites in your `wrangler.toml`:
 
-| Key           | Value                                                                              | Example                          |
-| ------------- | ---------------------------------------------------------------------------------- | -------------------------------- |
-| `bucket`      | The directory containing your static assets, path relative to your `wrangler.toml` | `bucket = "./public"`              |
-| `entry-point` | The location of your Worker script, default is `workers-site`                      | `entry-point = "./workers-site"` |
+| Key           | Value                                                                              | Example                          | Required |
+| ------------- | ---------------------------------------------------------------------------------- | -------------------------------- | -------- |
+| `bucket`      | The directory containing your static assets, path relative to your `wrangler.toml` | `bucket = "./public"`            | yes      |
+| `entry-point` | The location of your Worker script, default is `workers-site`                      | `entry-point = "./workers-site"` | yes      |
+| `include`     | A list of gitignore-style patterns for files or directories in `bucket` you exclusively want to upload. | `include = ["upload_dir"]` | no |
+| `exclude`     | A list of gitignore-style patterns for files or directories in `bucket` you want to exclude from uploads. | `exclude = ["ignore_dir"]` | no |
 
 _Note: if your project uses [environments](https://github.com/cloudflare/wrangler/blob/master/docs/content/environments.md), make sure to place `site` at the top level config._
 

--- a/content/sites/reference.md
+++ b/content/sites/reference.md
@@ -36,6 +36,8 @@ There are a few specific configuration settings for Workers Sites in your `wrang
 | `include`     | A list of gitignore-style patterns for files or directories in `bucket` you exclusively want to upload. | `include = ["upload_dir"]` | no |
 | `exclude`     | A list of gitignore-style patterns for files or directories in `bucket` you want to exclude from uploads. | `exclude = ["ignore_dir"]` | no |
 
+To learn more about the optional `include` and `exclude` fields, visit [Ignoring Subsets of Static Assets](/sites/ignore-assets).
+
 _Note: if your project uses [environments](https://github.com/cloudflare/wrangler/blob/master/docs/content/environments.md), make sure to place `site` at the top level config._
 
 Example of a `wrangler.toml`:

--- a/content/sites/reference.md
+++ b/content/sites/reference.md
@@ -4,7 +4,7 @@ alwaysopen: true
 weight: 6
 ---
 
-Worker Sites require the latest version of [Wrangler](https://github.com/cloudflare/wrangler) and the Workers [Unlimited plan](https://workers.cloudflare.com/sites#plans).
+Workers Sites require the latest version of [Wrangler](https://github.com/cloudflare/wrangler) and the Workers [Unlimited plan](https://workers.cloudflare.com/sites#plans).
 
 ### Commands
 

--- a/content/sites/start-from-existing.md
+++ b/content/sites/start-from-existing.md
@@ -4,7 +4,7 @@ alwaysopen: true
 weight: 3
 ---
 
-Worker Sites require [Wrangler](https://github.com/cloudflare/wrangler) - make sure to be on the [latest version](/quickstart/#updating-the-cli) - and the Workers [Unlimited plan](https://workers.cloudflare.com/sites#plans).
+Workers Sites require [Wrangler](https://github.com/cloudflare/wrangler) - make sure to be on the [latest version](/quickstart/#updating-the-cli) - and the Workers [Unlimited plan](https://workers.cloudflare.com/sites#plans).
 
 To deploy a pre-existing static site project, you'll need to start with a pre-generated site. Workers Sites works well with all static site generators! For a quick-start, check out the following projects:
 

--- a/content/sites/start-from-scratch.md
+++ b/content/sites/start-from-scratch.md
@@ -6,7 +6,7 @@ weight: 2
 
 To start from scratch to create a Workers Site, follow these steps:
 
-1. Ensure you have the latest version of [Wrangler](/quickstart#installing-the-cli) and Node.js installed. Worker Sites require the Workers [Unlimited plan](https://workers.cloudflare.com/sites#plans).
+1. Ensure you have the latest version of [Wrangler](/quickstart#installing-the-cli) and Node.js installed. Workers Sites require the Workers [Unlimited plan](https://workers.cloudflare.com/sites#plans).
 
 2. In your terminal run `wrangler generate --site <project-name>`, replacing `<project-name>` with the name of your project. For example, I'll create a project called my-site by running this command:
    ```

--- a/content/sites/start-from-worker.md
+++ b/content/sites/start-from-worker.md
@@ -4,7 +4,7 @@ alwaysopen: true
 weight: 4
 ---
 
-Worker Sites require [Wrangler](https://github.com/cloudflare/wrangler) - make sure to be on the [latest version](/quickstart/#updating-the-cli) - and the Workers [Unlimited plan](https://workers.cloudflare.com/sites#plans).
+Workers Sites require [Wrangler](https://github.com/cloudflare/wrangler) - make sure to be on the [latest version](/quickstart/#updating-the-cli) - and the Workers [Unlimited plan](https://workers.cloudflare.com/sites#plans).
 
 Make sure to be on the latest version.
 


### PR DESCRIPTION
This PR updates the wrangler reference page to include the new `include/exclude` fields for wrangler's sites settings, as well as adds a new docs page about wrangler ignore functionality.

This PR also has additional content that exists in master but not in staging yet.