### PR TITLE
Add template IDs

### DIFF
--- a/data/snippet/ab_testing.toml
+++ b/data/snippet/ab_testing.toml
@@ -1,3 +1,4 @@
+id = "ab_testing"
 name = "A/B Testing"
 description = "Set up an A/B test by controlling what response is served based on cookies"
 code = '''

--- a/data/snippet/alter_headers.toml
+++ b/data/snippet/alter_headers.toml
@@ -1,3 +1,4 @@
+id = "alter_headers"
 name = "Alter Headers"
 description = "Change the headers sent in a request or returned in a response"
 code ='''async function handleRequest(request) {

--- a/data/snippet/conditional_response.toml
+++ b/data/snippet/conditional_response.toml
@@ -1,3 +1,4 @@
+id = "conditional_response"
 name = "Conditional Response"
 description = "Return a response based on the incoming request's URL, HTTP method, User Agent, IP address, ASN or device type (e.g. mobile)"
 code = """const BLOCKED_HOSTNAMES = ['nope.mywebsite.com', 'bye.website.com']

--- a/data/snippet/debugging.toml
+++ b/data/snippet/debugging.toml
@@ -1,3 +1,4 @@
+id = "debugging_tips"
 name = "Debugging Tips"
 description = "Send debug information in an errored response and to a logging service."
 code = """const LOG_URL = 'https://log-service.example.com/' // Service setup up to receive logs

--- a/data/snippet/hot_link_protection.toml
+++ b/data/snippet/hot_link_protection.toml
@@ -1,3 +1,4 @@
+id = "hotlink_protection"
 name = "Hot-link Protection"
 description = "Block other websites from linking to your content"
 code = """

--- a/data/snippet/http2_push.toml
+++ b/data/snippet/http2_push.toml
@@ -1,3 +1,4 @@
+id = "http2_server_push"
 name = "HTTP/2 Server Push"
 description = "Push static assests to a client's browser without waiting for HTML to render"
 code = """async function handleRequest(request) {

--- a/data/snippet/tls_version.toml
+++ b/data/snippet/tls_version.toml
@@ -1,3 +1,4 @@
+id = "block_on_tls_version"
 name = "Block on TLS Version"
 description = "Inspects the incoming request's TLS version and blocks if under TLSv1.2."
 code = """


### PR DESCRIPTION
This PR adds ids for templates that are missing them. This should fix an issue where some snippets weren't showing up as results from the search bar.

Closes #411, closes #383