### PR TITLE
Update burst limits docs to reflect latest limits

### DIFF
--- a/content/about/limits.md
+++ b/content/about/limits.md
@@ -35,7 +35,7 @@ The burst rate and daily request limits apply at the account level, meaning that
 
 ### Burst Rate Limit
 
-Accounts using the Workers free plan are subject to a burst rate limit of 1000 requests per 10 minutes. Users visiting a rate limited site will receive a Cloudflare 1015 error page. However if you are calling your script programmatically, you can detect the rate limit page and handle it yourself by looking for HTTP status code 429.
+Accounts using the Workers free plan are subject to a burst rate limit of 1000 requests per minute. Users visiting a rate limited site will receive a Cloudflare 1015 error page. However if you are calling your script programmatically, you can detect the rate limit page and handle it yourself by looking for HTTP status code 429.
 
 ### Daily Request Limit
 


### PR DESCRIPTION
The burst rate limit has changed from 1000 requests per 10 minutes to 1000 requests per minute.