### PR TITLE
typo in references/cache

### DIFF
--- a/content/reference/apis/cache.md
+++ b/content/reference/apis/cache.md
@@ -76,7 +76,8 @@ cache.match(request, options)
 
 - `request`: The string or [`Request`](/reference/apis/request) object used as the lookup key. Strings are interpreted as the URL for a new `Request` object.
 
-- `options`: Can contain one possible property: \* `ignoreMethod` (Boolean): Consider the request method a GET regardless of its actual value.
+- `options`: Can contain one possible property: 
+  - `ignoreMethod` (Boolean): Consider the request method a GET regardless of its actual value.
 
 Unlike the browser Cache API, Cloudflare Workers do not support the `ignoreSearch` or `ignoreVary` options on `match()`. You can accomplish this behavior by removing query strings or HTTP headers at `put()` time.
 

--- a/content/reference/apis/cache.md
+++ b/content/reference/apis/cache.md
@@ -82,11 +82,11 @@ Unlike the browser Cache API, Cloudflare Workers do not support the `ignoreSearc
 
 Our implementation of the Cache API respects the following HTTP headers on the request passed to `match()`:
 
-    - `Range`: Results in a `206` response if a matching response is found. Your Cloudflare cache always respects range requests, even if an `Accept-Ranges` header is on the response.
+- `Range`: Results in a `206` response if a matching response is found. Your Cloudflare cache always respects range requests, even if an `Accept-Ranges` header is on the response.
 
-    - `If-Modified-Since`: Results in a `304` response if a matching response is found with a `Last-Modified` header with a value after the time specified in `If-Modified-Since`.
+- `If-Modified-Since`: Results in a `304` response if a matching response is found with a `Last-Modified` header with a value after the time specified in `If-Modified-Since`.
 
-    - `If-None-Match`: Results in a `304` response if a matching response is found with an `ETag` header with a value that matches a value in `If-None-Match`.
+- `If-None-Match`: Results in a `304` response if a matching response is found with an `ETag` header with a value that matches a value in `If-None-Match`.
 
 `cache.match()`: Never sends a subrequest to the origin. If no matching response is found in cache, the promise that `cache.match()` returns is fulfilled with `undefined`.
 

--- a/content/reference/apis/cache.md
+++ b/content/reference/apis/cache.md
@@ -78,14 +78,17 @@ cache.match(request, options)
 
 - `options`: Can contain one possible property: \* `ignoreMethod` (Boolean): Consider the request method a GET regardless of its actual value.
 
-      	Unlike the browser Cache API, Cloudflare Workers do not support the `ignoreSearch` or `ignoreVary` options on `match()`. You can accomplish this behavior by removing query strings or HTTP headers at `put()` time.
+Unlike the browser Cache API, Cloudflare Workers do not support the `ignoreSearch` or `ignoreVary` options on `match()`. You can accomplish this behavior by removing query strings or HTTP headers at `put()` time.
 
-      	Our implementation of the Cache API respects the following HTTP headers on the request passed to `match()`:
+Our implementation of the Cache API respects the following HTTP headers on the request passed to `match()`:
 
-      	* `Range`: Results in a `206` response if a matching response is found. Your Cloudflare cache always respects range requests, even if an `Accept-Ranges` header is on the response.
-      	* `If-Modified-Since`: Results in a `304` response if a matching response is found with a `Last-Modified` header with a value after the time specified in `If-Modified-Since`.
-      	* `If-None-Match`: Results in a `304` response if a matching response is found with an `ETag` header with a value that matches a value in `If-None-Match`.
-      	`cache.match()`: Never sends a subrequest to the origin. If no matching response is found in cache, the promise that `cache.match()` returns is fulfilled with `undefined`.
+    - `Range`: Results in a `206` response if a matching response is found. Your Cloudflare cache always respects range requests, even if an `Accept-Ranges` header is on the response.
+
+    - `If-Modified-Since`: Results in a `304` response if a matching response is found with a `Last-Modified` header with a value after the time specified in `If-Modified-Since`.
+
+    - `If-None-Match`: Results in a `304` response if a matching response is found with an `ETag` header with a value that matches a value in `If-None-Match`.
+
+`cache.match()`: Never sends a subrequest to the origin. If no matching response is found in cache, the promise that `cache.match()` returns is fulfilled with `undefined`.
 
 #### `delete`
 

--- a/content/reference/apis/cache.md
+++ b/content/reference/apis/cache.md
@@ -104,9 +104,9 @@ cache.delete(request, options)
 
 - `request`: The lookup key as a string or [`Request`](/reference/apis/request) object. String are interpreted as the URL for a new `Request` object.
 
-- `optons`: Can contain one of these properties:
+- `options`: Can contain one of these properties:
 
-      	* `ignoreMethod` (Boolean): Consider the request method to `GET`, regardless of its actual value.
+    - `ignoreMethod` (Boolean): Consider the request method to `GET`, regardless of its actual value.
 
 ## More Information
 


### PR DESCRIPTION
small typo correction, and format.