### PR TITLE
UI Wrangler 1.5.0 and Hugo 0.59.0

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install deps
       run: npm install
     - name: Install Hugo
-      run: sudo apt-get install hugo
+      run: sudo apt install hugo
     - name: Copy config for hugo
       run: cp config-staging.toml config.toml
     - name: Build docs

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install deps
       run: npm install
     - name: Install Hugo
-      run: sudo apt install hugo
+      run: sudo snap install hugo
     - name: Copy config for hugo
       run: cp config-staging.toml config.toml
     - name: Build docs

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Build docs
       run: hugo
     - name: Install Wrangler
-      run: npm i @cloudflare/wrangler@1.4.0-rc.7 -g
+      run: npm i @cloudflare/wrangler@1.5.0 -g
     - name: Wrangler auth check
       run: wrangler whoami
       env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install deps
       run: npm install
     - name: Install Hugo
-      run: sudo apt install hugo
+      run: sudo snap install hugo
     - name: Copy config for hugo
       run: cp config-production.toml config.toml
     - name: Build docs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install deps
       run: npm install
     - name: Install Hugo
-      run: sudo apt-get install hugo
+      run: sudo apt install hugo
     - name: Copy config for hugo
       run: cp config-production.toml config.toml
     - name: Build docs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Build docs
       run: hugo
     - name: Install Wrangler
-      run: npm i @cloudflare/wrangler@1.4.0-rc.7 -g
+      run: npm i @cloudflare/wrangler@1.5.0 -g
     - name: Wrangler auth check
       run: wrangler whoami
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install deps
       run: npm install
     - name: Install Hugo
-      run: sudo apt install hugo
+      run: sudo snap install hugo
     - name: Install Wrangler
       run: npm i @cloudflare/wrangler@1.5.0 -g
     - name: Install Workers script deps

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install deps
       run: npm install
     - name: Install Hugo
-      run: sudo apt-get install hugo
+      run: sudo apt install hugo
     - name: Install Wrangler
       run: npm i @cloudflare/wrangler@1.5.0 -g
     - name: Install Workers script deps

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install Hugo
       run: sudo apt-get install hugo
     - name: Install Wrangler
-      run: npm i @cloudflare/wrangler@1.4.0-rc.7 -g
+      run: npm i @cloudflare/wrangler@1.5.0 -g
     - name: Install Workers script deps
       run: npm install
     - name: Build docs


### PR DESCRIPTION
Two bumps:
* Wrangler 1.5.0
* Hugo 0.59.0 (using `apt-get` limit to v0.40.1, where `snap` v0.59.0)

The "New" bullet was not applied previously because of Hugo version v0.40.1, now it is shown.

v0.59.0
<img width="400" alt="Screen Shot 2019-10-29 at 1 01 35 PM" src="https://user-images.githubusercontent.com/17833/67775285-a4c4c080-fa56-11e9-935d-d85e1c684954.png">

v0.40.1
<img width="400" alt="Screen Shot 2019-10-29 at 1 01 41 PM" src="https://user-images.githubusercontent.com/17833/67775286-a55d5700-fa56-11e9-9954-7d7d85c3c8f1.png">
