### PR TITLE
Add list method to API docs

### DIFF
--- a/content/reference/storage/api.md
+++ b/content/reference/storage/api.md
@@ -243,6 +243,22 @@ If you want the keys you write to be automatically deleted at some time in the f
 
 As with all updates, deletes can take up to ten seconds to propagate globally.
 
+#### List Keys
+
+`NAMESPACE.list({ [prefix], [limit], [cursor] })`
+
+Like with the `get` method, the `list` method returns a promise you can `await` to get the value. The promise resolves to an object that looks like this:
+
+```
+{
+  keys: [{ name: "foo", expiration: 1234}],
+  list_complete: false,
+  cursor: "6Ck1la0VxJ0djhidm1MdX2FyD"
+}
+```
+
+For more information about listing keys, and pagination using `cursor` and `list_complete`, see the page [listing keys]({{<ref "listing-keys.md" >}}).
+
 <style>
 h4 !important {
   font-size: 1rem;

--- a/content/reference/storage/api.md
+++ b/content/reference/storage/api.md
@@ -5,7 +5,7 @@ weight: 50
 
 The Cloudflare API is the best way to write data into Workers KV.
 
-Read about [writing data]({{< ref "writing-data.md" >}}) for an introduction to our API.
+Read about [writing data](/reference/storage/writing-data/) for an introduction to our API.
 
 For full documentation of all Workers KV API methods, see the [Cloudflare API documentation](https://api.cloudflare.com/#workers-kv-namespace-properties).
 
@@ -235,7 +235,7 @@ The type is automatically inferred from value, and can be any of:
 - ReadableStream
 - ArrayBuffer
 
-If you want the keys you write to be automatically deleted at some time in the future, see the page on [expiring keys]({{<ref "expiring-keys.md" >}}).
+If you want the keys you write to be automatically deleted at some time in the future, see the page on [expiring keys](/reference/storage/expiring-keys/).
 
 #### Delete Value
 
@@ -257,7 +257,7 @@ Like with the `get` method, the `list` method returns a promise you can `await` 
 }
 ```
 
-For more information about listing keys, and pagination using `cursor` and `list_complete`, see the page [listing keys]({{<ref "listing-keys.md" >}}).
+For more information about listing keys, and pagination using `cursor` and `list_complete`, see the page [listing keys](/reference/storage/listing-keys/).
 
 <style>
 h4 !important {


### PR DESCRIPTION
Fixes #482.

**Changelog**

1. ~Converted existing methods to use standard documentation syntax and highlighting.
    I intentionally left off the expiration options from `put` since they were omitted previously and are already linked out to the page with more info.~
1. Added the `list` method documentation and link to the dedicated page with more info.