### PR TITLE
Change wording of old concepts sections

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -58,8 +58,8 @@ title: Cloudflare Workers Documentation
     <p>Global variables immediately available in your code</p>
   </div>
   <div>
-    <a href="/reference/workers-concepts">Concepts</a>
-    <p>The need to know while writing Workers scripts.</p>
+    <a href="/about">About</a>
+    <p>Learn about the Workers platform.</p>
   </div>
   <div>
     <a href="/tooling">Tooling</a>

--- a/content/quickstart/_index.md
+++ b/content/quickstart/_index.md
@@ -141,11 +141,9 @@ We'll use this approach in the [Slack Bot Tutorial](/tutorials/build-an-applicat
 
 There are a variety of examples in the [Template Gallery](/templates) for more custom solutions.
 
-### Workers Concepts
+### Runtime APIs
 
 The example outlined in this guide is just a starting point. There are many more [APIs](/reference/runtime/apis) available to manipulate intercepted requests. For example, you can retrieve data from [Cache](/reference/apis/cache), compute a custom response right from the edge, route the request to the appropriate service, filter traffic, and more.
-
-For concepts, pitfalls and guidelines to keep in mind while writing scripts, check out our [Workers Concepts](/reference/workers-concepts) articles.
 
 # Preview Your Project
 


### PR DESCRIPTION
fixes #508 

We no longer want to advertise the concepts section. About is now for those curious on how the platform works, we hope to remove the tips section to be templates with tutorial explanations in the near future 