### PR TITLE
Fix bad demo link

### DIFF
--- a/data/featured/emscripten.toml
+++ b/data/featured/emscripten.toml
@@ -2,6 +2,6 @@ id = "emscripten"
 name = "Emscripten + Wasm Image Resizer"
 description = "Image Resizer in C compiled to Wasm with Emscripten"
 repository_url = "https://github.com/cloudflare/worker-emscripten-template"
-demo_url = "https://cloudflareworkers.com/#ddb7fa39e09cdf734180c5d083ddb390:http://placehold.jp/1200x800.png?width=100"
+demo_url = "https://cloudflareworkers.com/#ddb7fa39e09cdf734180c5d083ddb390:http://placehold.jp/1200x800.png"
 
 tags = ['Wasm']


### PR DESCRIPTION
Ideally,  GA would treat demo links with a `?` and `#` the same as links with no `?`(i.e. just append the `? _ga=X.XXX` instead of trying to append it to an existing query param ` "&_ga=X.XXX"`). 
Quoting Kenton:
> This appears to be a bug with the way Google Analytics appends itself to links. It should have used a `?` but it instead used an `&`, probably because it noticed that there was already a `?` in the link -- but that `?` appears after the `#`, a totally different part of the link text...


In the meantime, we should not accept any more templates with demo links with query strings. 
