### PR TITLE
Update env var docs

### DIFF
--- a/content/quickstart/_index.md
+++ b/content/quickstart/_index.md
@@ -210,15 +210,25 @@ It should not be stored in version control or in your code, use environment vari
 
 ## Setup
 
-Set up your default credentials on your local machine via the `config` subcommand. You should only need to do this once. Running `wrangler config` will prompt you interactively for your email and API key:
+Set up your default credentials on your local machine via the `config` subcommand. This is an interactive command that will prompt you for your API token:
 
-```sh
-$ wrangler config
-Enter email:
-foo@bar.com
-Enter api key:
-123456abcdef
+```bash
+wrangler config
+Enter API token:
+superlongapitoken
 ```
+
+You can also provide your email and global API key (this is not recommended for security reasons):
+
+```bash
+wrangler config --api-key
+Enter email:
+testuser@example.com
+Enter global API key:
+superlongapikey
+```
+
+You can also [use environment variables](https://developers.cloudflare.com/workers/tooling/wrangler/configuration/) to configure these authentication credentials.
 
 To configure your project, complete the `wrangler.toml` file at the root of the generated project. This file contains the information wrangler needs to connect to the Cloudflare Workers API, and publish your code.
 

--- a/content/quickstart/_index.md
+++ b/content/quickstart/_index.md
@@ -224,7 +224,7 @@ Enter API token:
 superlongapitoken
 ```
 
-You can also provide your email and global API key (this is not recommended for security reasons):
+You can also provide your email and global API key:
 
 ```bash
 wrangler config --api-key

--- a/content/quickstart/_index.md
+++ b/content/quickstart/_index.md
@@ -11,10 +11,9 @@ weight: 1
 - [Preview Your Project](#preview-your-project)
 - [Build Your Project](#build-your-project)
 - [Configure](#configure)
-  - [Authentication](#authentication)
-    - [Account ID and Zone ID](#account-id-and-zone-id)
-    - [API Token](#api-token)
-    - [Global API Key](#global-api-key)
+  - [Account ID and Zone ID](#account-id-and-zone-id)
+  - [API Token](#api-token)
+  - [Global API Key](#global-api-key)
   - [Setup](#setup)
 - [Publish Your Project](#publish-your-project)
   - [Publish To workers.dev](#publish-to-workers-dev)
@@ -174,15 +173,13 @@ $ wrangler build
 
 To publish Cloudflare Workers projects and serve them from our global cloud network, [create a Cloudflare account](https://dash.cloudflare.com/sign-up/workers) and setup a registered domain **_or_** a Workers.dev subdomain on Cloudflare.
 
-## Authentication
-
 [Wrangler](/tooling/wrangler) and [other tools](/tooling) use the following credentials to manage uploading and publishing your Worker scripts to your Cloudflare domain:
 
 - Account ID
 - Zone ID _(Note You do not need your Zone ID for deploying Workers on a `Workers.dev` subdomain)_
 - API Token OR the pair of Email address and Global API Key. API Tokens are preferred.
 
-### Account ID and Zone ID
+## Account ID and Zone ID
 
 **Registered Domains**
 
@@ -200,15 +197,15 @@ For workers.dev domains, you will just need the Account ID:
 1. Log in to your Cloudflare account and select **Workers**.
 2. Scroll to the _API_ section and select **Click to copy** to copy your **Account ID**.
 
-### API Token
+## API Token
 
-1. Click **[Get API Token](https://dash.cloudflare.com/profile/api-tokens)** below the _API_ section to jump to your _Profile_ page.
+1. Click **Get API Token** below the _API_ section to jump to your _Profile_ page.
 2. Click **Create Token** and select the **Start with Template** radio button. Select the **Edit Cloudflare Workers** template.
 3. Fill out the rest of the fields and then click **Continue to Summary**, where you can click **Create Token** and issue your token for use.
 
-### Global API Key
+## Global API Key
 
-1. Click **[Get API Token](https://dash.cloudflare.com/profile/api-tokens)** below the _API_ section to jump to your _Profile_ page.
+1. Click **Get API Token** below the _API_ section to jump to your _Profile_ page.
 2. Scroll to _API Keys_, and click **View** to copy your Global API Key **\***.
 
 **\* IMPORTANT: Treat your Global API Key like a password!**

--- a/content/quickstart/_index.md
+++ b/content/quickstart/_index.md
@@ -11,8 +11,9 @@ weight: 1
 - [Preview Your Project](#preview-your-project)
 - [Build Your Project](#build-your-project)
 - [Configure](#configure)
-  - [Finding Your Cloudflare API Keys](#finding-your-cloudflare-api-keys)
+  - [Authentication](#authentication)
     - [Account ID and Zone ID](#account-id-and-zone-id)
+    - [API Token](#api-token)
     - [Global API Key](#global-api-key)
   - [Setup](#setup)
 - [Publish Your Project](#publish-your-project)
@@ -173,14 +174,13 @@ $ wrangler build
 
 To publish Cloudflare Workers projects and serve them from our global cloud network, [create a Cloudflare account](https://dash.cloudflare.com/sign-up/workers) and setup a registered domain **_or_** a Workers.dev subdomain on Cloudflare.
 
-## Finding Your Cloudflare API Keys
+## Authentication
 
 [Wrangler](/tooling/wrangler) and [other tools](/tooling) use the following credentials to manage uploading and publishing your Worker scripts to your Cloudflare domain:
 
 - Account ID
 - Zone ID _(Note You do not need your Zone ID for deploying Workers on a `Workers.dev` subdomain)_
-- Global API Key
-- Email address
+- API Token OR the pair of Email address and Global API Key. API Tokens are preferred.
 
 ### Account ID and Zone ID
 
@@ -200,9 +200,15 @@ For workers.dev domains, you will just need the Account ID:
 1. Log in to your Cloudflare account and select **Workers**.
 2. Scroll to the _API_ section and select **Click to copy** to copy your **Account ID**.
 
+### API Token
+
+1. Click **Get API Token** below the _API_ section to jump to your _Profile_ page.
+2. Click **Create Token** and select the **Start with Template** radio button. Select the **Edit Cloudflare Workers** template.
+3. Fill out the rest of the fields and then click **Continue to Summary**, where you can click **Create Token** and issue your token for use.
+
 ### Global API Key
 
-1. Click **Get API Key** below the _API_ section to jump to your _Profile_ page.
+1. Click **Get API Token** below the _API_ section to jump to your _Profile_ page.
 2. Scroll to _API Keys_, and click **View** to copy your Global API Key **\***.
 
 **\* IMPORTANT: Treat your Global API Key like a password!**

--- a/content/tooling/api/requests.md
+++ b/content/tooling/api/requests.md
@@ -9,9 +9,12 @@ All requests to the Cloudflare Workers REST API must
 
 - be sent over HTTPS
 - Send a JSON body (unless otherwise indicated)
-- contain valid identification headers ([Find your Cloudflare Auth info](/quickstart#finding-your-cloudflare-api-keys)).
-  - `X-Auth-Email` - the email address attached to your Cloudflare profile.
-  - `X-Auth-Key` - the Global API key attached to your Cloudflare profile.
+- contain valid identification headers ([Find your Cloudflare Auth info](/quickstart#authentication)).
+  - Using API Tokens:
+    - `Authorization` - provide an API token in standard `Bearer <token>` format.
+  - Using Email and Global API Key
+    - `X-Auth-Email` - the email address attached to your Cloudflare profile.
+    - `X-Auth-Key` - the Global API key attached to your Cloudflare profile.
 
 ## API Responses
 

--- a/content/tooling/wrangler/commands.md
+++ b/content/tooling/wrangler/commands.md
@@ -69,7 +69,7 @@ weight: 2
   superlongapikey
   ```
 
-  You can also [use environment variables](https://developers.cloudflare.com/workers/tooling/wrangler/configuration/) to configure these values.
+  You can also [use environment variables](/tooling/wrangler/configuration/) to configure these values.
 
 ### ☁️ 🆙 `publish`
 

--- a/content/tooling/wrangler/commands.md
+++ b/content/tooling/wrangler/commands.md
@@ -52,17 +52,24 @@ weight: 2
 
 ### 🔧 `config`
 
-  Configure your global Cloudflare user. This is an interactive command that will prompt you for your email and API key:
+  Configure your global Cloudflare user. This is an interactive command that will prompt you for your API token:
 
   ```bash
   wrangler config
-  Enter email:
-  testuser@example.com
-  Enter api key:
-  ...
+  Enter API token:
+  superlongapitoken
   ```
 
-  You can also [use environment variables](#using-environment-variables) to configure these values.
+  You can also provide your email and global API key (this is not recommended for security reasons):
+  ```bash
+  wrangler config --api-key
+  Enter email:
+  testuser@example.com
+  Enter global API key:
+  superlongapikey
+  ```
+
+  You can also [use environment variables](https://developers.cloudflare.com/workers/tooling/wrangler/configuration/) to configure these values.
 
 ### ☁️ 🆙 `publish`
 

--- a/content/tooling/wrangler/configuration/_index.md
+++ b/content/tooling/wrangler/configuration/_index.md
@@ -45,6 +45,9 @@ There are two types of configuration that `wrangler` uses: global user and per p
   # $CF_API_KEY -> your Cloudflare API key
   ```
 
+  Note that providing authentication credentials through environment variables will override whatever credentials you configured 
+  if you ran `wrangler config`.
+
 ### Per Project
 
   Your project will need to have several things configured before you can publish your worker. These values are stored in a `wrangler.toml` file that `wrangler generate` will make for you. You will need to manually edit this file to add these values before you can publish.

--- a/content/tooling/wrangler/configuration/_index.md
+++ b/content/tooling/wrangler/configuration/_index.md
@@ -24,14 +24,25 @@ There are two types of configuration that `wrangler` uses: global user and per p
   
 #### Using environment variables
 
-  You can also configure your global user with environment variables. This is the preferred method for using Wrangler in CI:
+  You can also configure your global user with environment variables. This is the preferred method for using Wrangler in CI.
+
+  You can deploy with authentication tokens (recommended):
 
   ```bash
   # e.g.
-  CF_API_KEY=superlongapikey CF_EMAIL=testuser@example.com wrangler publish --release
+  CF_API_TOKEN=superlongapitoken wrangler publish
   # where
-  # $CF_API_KEY -> your Cloudflare API key
+  # $CF_API_TOKEN -> a Cloudflare API token
+  ```
+
+  Or you can deploy with your email and your global API key:
+
+  ```bash
+  # e.g.
+  CF_EMAIL=testuser@example.com CF_API_KEY=superlongapikey wrangler publish --release
+  # where
   # $CF_EMAIL -> your Cloudflare account email
+  # $CF_API_KEY -> your Cloudflare API key
   ```
 
 ### Per Project

--- a/content/tooling/wrangler/configuration/_index.md
+++ b/content/tooling/wrangler/configuration/_index.md
@@ -39,7 +39,7 @@ There are two types of configuration that `wrangler` uses: global user and per p
 
   ```bash
   # e.g.
-  CF_EMAIL=testuser@example.com CF_API_KEY=superlongapikey wrangler publish --release
+  CF_EMAIL=testuser@example.com CF_API_KEY=superlongapikey wrangler publish
   # where
   # $CF_EMAIL -> your Cloudflare account email
   # $CF_API_KEY -> your Cloudflare API key

--- a/content/tooling/wrangler/configuration/_index.md
+++ b/content/tooling/wrangler/configuration/_index.md
@@ -44,7 +44,6 @@ There are two types of configuration that `wrangler` uses: global user and per p
   # $CF_EMAIL -> your Cloudflare account email
   # $CF_API_KEY -> your Cloudflare API key
   ```
-
   Note that providing authentication credentials through environment variables will override whatever credentials you configured 
   if you ran `wrangler config`.
 


### PR DESCRIPTION
Closes #327 and closes #519.

This PR updates the docs for environment variables to also include an API tokens example, as well as a note on how env var vs. config file precedence works.