### PR TITLE
Fix formatting on routes page

### DIFF
--- a/content/about/routes.md
+++ b/content/about/routes.md
@@ -92,13 +92,9 @@ Here is the full set of rules governing route pattern validity:
 
 - **Hostnames may optionally begin with `*`**
 
-      If a route pattern hostname begins with `*`, then it matches the host *and* all
+      If a route pattern hostname begins with `*`, then it matches the host *and* all subhosts.
 
-  subhosts.
-
-      If a route pattern hostname begins with `*.`, then it matches *only* all
-
-  subhosts.
+      If a route pattern hostname begins with `*.`, then it matches *only* all subhosts.
 
       - `*example.com/` matches `https://example.com/` *and* `https://www.example.com/`
 

--- a/content/about/routes.md
+++ b/content/about/routes.md
@@ -84,22 +84,19 @@ Here is the full set of rules governing route pattern validity:
   https:// URLs. If you include http:// or https://, it will only match HTTP
   or HTTPS requests, respectively.
 
-  - `https://*.example.com/` matches `https://www.example.com/` but _not_
-    `http://www.example.com/`
+  - `https://*.example.com/` matches `https://www.example.com/` but _not_ `http://www.example.com/`
 
-  - `*.example.com/` matches both `https://www.example.com/` _and_
-    `http://www.example.com/`.
+  - `*.example.com/` matches both `https://www.example.com/` _and_ `http://www.example.com/`.
 
 - **Hostnames may optionally begin with `*`**
 
-      If a route pattern hostname begins with `*`, then it matches the host *and* all subhosts.
+   If a route pattern hostname begins with `*`, then it matches the host *and* all subhosts.
 
-      If a route pattern hostname begins with `*.`, then it matches *only* all subhosts.
+   If a route pattern hostname begins with `*.`, then it matches *only* all subhosts.
 
-      - `*example.com/` matches `https://example.com/` *and* `https://www.example.com/`
+   - `*example.com/` matches `https://example.com/` *and* `https://www.example.com/`
 
-      - `*.example.com/` matches `https://www.example.com/` but *not*
-      `https://example.com/`
+   - `*.example.com/` matches `https://www.example.com/` but *not* `https://example.com/`
 
 - **Paths may optionally end with `*`**
 


### PR DESCRIPTION
I was reading the docs and noticed this formatting issue, so I clicked on the "edit on github" link at the top and edited it.

![image](https://user-images.githubusercontent.com/13520392/69472626-1a236880-0d59-11ea-8363-5251fa993007.png)

![image](https://user-images.githubusercontent.com/13520392/69472639-3aebbe00-0d59-11ea-95ad-9afebf04a11f.png)

