### PR TITLE
[WIP] Install pinned Hugo version in CI

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -18,7 +18,9 @@ jobs:
     - name: Install deps
       run: npm install
     - name: Install Hugo
-      run: sudo snap install hugo
+      run: |
+        wget https://github.com/gohugoio/hugo/releases/download/v0.59.1/hugo_0.59.1_Linux-64bit.deb
+        sudo dpkg -i hugo_0.59.1_Linux-64bit.deb
     - name: Copy config for hugo
       run: cp config-staging.toml config.toml
     - name: Build docs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,9 @@ jobs:
     - name: Install deps
       run: npm install
     - name: Install Hugo
-      run: sudo snap install hugo
+      run: |
+        wget https://github.com/gohugoio/hugo/releases/download/v0.59.1/hugo_0.59.1_Linux-64bit.deb
+        sudo dpkg -i hugo_0.59.1_Linux-64bit.deb
     - name: Copy config for hugo
       run: cp config-production.toml config.toml
     - name: Build docs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,11 @@ jobs:
     - name: Install deps
       run: npm install
     - name: Install Hugo
-      run: sudo snap install hugo
+      run: |
+        wget https://github.com/gohugoio/hugo/releases/download/v0.59.1/hugo_0.59.1_Linux-64bit.deb
+        sudo dpkg -i hugo_0.59.1_Linux-64bit.deb
+    - name: Check Hugo version
+      run: hugo version
     - name: Install Wrangler
       run: npm i @cloudflare/wrangler@1.5.0 -g
     - name: Install Workers script deps


### PR DESCRIPTION
**[WIP] I need to confirm that these commands work by running this on our mirror repo.**

This fixes a current issue in the deployed version of our docs where the newest version of hugo is unable to build both of our `index` files in `content/`. Building without the placeholder `content/_index.html` causes our sidebar to break. Since we'll eventually be moving off of this codebase, I'm OK to just pin a known-good version of Hugo here and build with that (the last patch-level version for the 0.59.x series - 0.59.1)

Note that this reverts some work from #489 - we now know that we want to be on a newer version of Hugo then prior to that commit, but not so new that we move to 0.60.0 and have to fix a bunch of things in the codebase.