### PR TITLE
Meta data for template pages

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -21,11 +21,9 @@
     {{end}}
 
     <div id="body-inner">
-      {{if not .IsHome}}
+      {{if and (ne .Section "templates") (not .IsHome) }}
       <h1>{{.Title}}</h1>
       {{end}}
-
-
       {{ .Content }}
     </div>
   </div>

--- a/workers-site/src/main.js
+++ b/workers-site/src/main.js
@@ -62,7 +62,10 @@ export async function handleRequest(event) {
         description: templateJSON.description,
       }
       // Rewrite all meta titles/descriptions the the correct title
-      return await new HTMLRewriter().on('meta', new MetaHandler(metaInfo)).transform(body)
+      return await new HTMLRewriter()
+        .on('meta', new MetaHandler(metaInfo))
+        .on('head>title', new TitleHandler(metaInfo))
+        .transform(body)
     }
     return body
   } catch (err) {
@@ -86,5 +89,13 @@ class MetaHandler {
     if (type.includes('description')) {
       element.setAttribute('content', this.meta.description)
     }
+  }
+}
+class TitleHandler {
+  constructor(content) {
+    this.content = { ...content }
+  }
+  element(element) {
+    element.setInnerContent(this.content.title)
   }
 }


### PR DESCRIPTION
Have template pages collect title and description from the registry so search results don't look like:

![image](https://user-images.githubusercontent.com/7578652/70748837-6aef0700-1cf0-11ea-8be7-ca5ae4eb75a7.png)

Related https://github.com/cloudflare/workers-docs/issues/385