### PR TITLE
Add mentions of required CF_ACCOUNT_ID env var

### DIFF
--- a/content/tooling/wrangler/configuration/_index.md
+++ b/content/tooling/wrangler/configuration/_index.md
@@ -30,7 +30,7 @@ There are two types of configuration that `wrangler` uses: global user and per p
 
   ```bash
   # e.g.
-
+  CF_ACCOUNT_ID=youraccountid
   CF_API_TOKEN=superlongapitoken wrangler publish
   # where
   # $CF_API_TOKEN -> a Cloudflare API token


### PR DESCRIPTION
Only setting the `CF_API_TOKEN` environment variable is not sufficient to automatically publish the project to workers.dev when using CI. It asks for excution of `wrangler config`, which further requires maunual input of user's account id. 
By setting `CF_ACCOUNT_ID`, `wrangler publish` will effectively submit the project. However, this environment variable is documented nowhere by far.