### PR TITLE
Fix broken relative links that incorrectly started with /workers/

### DIFF
--- a/content/reference/storage/listing-keys.md
+++ b/content/reference/storage/listing-keys.md
@@ -18,7 +18,7 @@ async function handleRequest(request) {
 }
 ```
 
-You can also [list keys on the command line with Wrangler](/workers/tooling/wrangler/kv_commands/#kv-key) or [via the API](https://api.cloudflare.com/#workers-kv-namespace-list-a-namespace-s-keys).
+You can also [list keys on the command line with Wrangler](/tooling/wrangler/kv_commands/#kv-key) or [via the API](https://api.cloudflare.com/#workers-kv-namespace-list-a-namespace-s-keys).
 
 ## More detail
 

--- a/content/reference/storage/namespaces.md
+++ b/content/reference/storage/namespaces.md
@@ -33,7 +33,7 @@ you specify.
 
 This will automatically happen on `wrangler publish` if you've [configured
 your namespace with
-Wrangler](/workers/tooling/wrangler/kv_commands/#concepts).
+Wrangler](/tooling/wrangler/kv_commands/#concepts).
 
 This can also be done from within the editor:
 
@@ -46,4 +46,4 @@ This can also be done from within the editor:
 &nbsp;
 
 Or, [via the API when you upload a
-script](/workers/archive/api/resource-bindings/kv-namespaces/).
+script](/archive/api/resource-bindings/kv-namespaces/).

--- a/content/reference/storage/reading-key-value-pairs.md
+++ b/content/reference/storage/reading-key-value-pairs.md
@@ -29,7 +29,7 @@ async function handleRequest(request) {
 ```
 
 You can also [read key-value pairs from the command line with
-wrangler](/workers/tooling/wrangler/kv_commands/#kv-key).
+wrangler](/tooling/wrangler/kv_commands/#kv-key).
 
 Finally, you can also [read from the
 API](https://api.cloudflare.com/#workers-kv-namespace-read-key-value-pair).

--- a/content/reference/storage/writing-key-value-pairs.md
+++ b/content/reference/storage/writing-key-value-pairs.md
@@ -16,7 +16,7 @@ The type is automatically inferred from value, and can be any of:
 - `ArrayBuffer`
 
 You can also [write key-value pairs from the command line with
-Wrangler](/workers/tooling/wrangler/kv_commands/#kv-key).
+Wrangler](/tooling/wrangler/kv_commands/#kv-key).
 
 Finally, you can [write data via the
 API](https://api.cloudflare.com/#workers-kv-namespace-write-key-value-pair).
@@ -27,7 +27,7 @@ to write data via Wrangler or the API, but read the data from within a worker.
 ## Writing Data in Bulk
 
 You can [write more than one key-value pair at a time with
-wrangler](/workers/tooling/wrangler/kv_commands/#kv-bulk) or [via the
+wrangler](/tooling/wrangler/kv_commands/#kv-bulk) or [via the
 API](https://api.cloudflare.com/#workers-kv-namespace-write-multiple-key-value-pairs).
 We do not support this from within a worker at this time.
 
@@ -80,5 +80,5 @@ These assume that `secondsSinceEpoch` and `secondsFromNow` are variables
 defined elsewhere in your Worker code.
 
 You can also [write with an expiration on the command line via
-Wrangler](/workers/tooling/wrangler/kv_commands/#kv-key) or [via the
+Wrangler](/tooling/wrangler/kv_commands/#kv-key) or [via the
 API](https://api.cloudflare.com/#workers-kv-namespace-write-key-value-pair).

--- a/content/sites/start-from-scratch.md
+++ b/content/sites/start-from-scratch.md
@@ -17,7 +17,7 @@ To start from scratch to create a Workers Site, follow these steps:
    - `workers-site`: The JavaScript for serving your assets. You don't need to edit this- but if you want to see how it works or add more functionality to your Worker, you can edit `workers-site/index.js`.
    - `wrangler.toml`: Your configuration file. You'll configure your account and project information here.
 
-3. Add your `account_id` your `wrangler.toml`. You can find your `account_id` on the right sidebar of the Workers or Overview Dashboard. Note: You may need to scroll down! For more details on finding your `account_id` click [here](https://developers.cloudflare.com/workers/quickstart/#account-id-and-zone-id).
+3. Add your `account_id` your `wrangler.toml`. You can find your `account_id` on the right sidebar of the Workers or Overview Dashboard. Note: You may need to scroll down! For more details on finding your `account_id` click [here](/quickstart/#account-id-and-zone-id).
 
 
 4. You can preview your site by running:
@@ -33,7 +33,7 @@ To start from scratch to create a Workers Site, follow these steps:
      zone_id = "42ef.."
      route = "example.com/*"
      ```
-   (Note: Check out documentation on [Routes](/workers/about/routes) to configure `route` properly) 
+   (Note: Check out documentation on [Routes](/about/routes) to configure `route` properly) 
      
  - **workers.dev**: Set `workers_dev`  to true. This is the default. 
 


### PR DESCRIPTION
This causes the resulting URLs in the browser to start with
/workers/workers/... which causes them to just send you to the home page
of the docs.

An example of a page with broken links is https://developers.cloudflare.com/workers/reference/storage/writing-key-value-pairs/

@steveklabnik 