### PR TITLE
Update documentation on cache key format

### DIFF
--- a/content/reference/apis/request.md
+++ b/content/reference/apis/request.md
@@ -81,7 +81,7 @@ Cloudflare features all plans can set on outbound requests:
 
 **Enterprise only:**
 
-- `cacheKey`: A request's cache key is what determines if two requests are "the same" for caching purposes. If a request has the same cache key as some previous request, then we can serve the same cached response for both. (e.g. `'some-key'`)
+- `cacheKey`: A request's cache key is what determines if two requests are "the same" for caching purposes. If a request has the same cache key as some previous request, then we can serve the same cached response for both. (e.g. `'https://example.com/some-url'`). Keys must be fully-qualified, valid URLs.
 - `cacheTtlByStatus`: This option is a version of the `cacheTtl` feature which chooses a TTL based on the response's status code. If the response to this request has a status code that matches, Cloudflare will cache for the instructed time, and override cache instructives sent by the origin. (e.g. `{ "200-299": 86400, 404: 1, "500-599": 0 }`)
   - _Note - Cloudflare will still adhere to [standard cache levels](https://support.cloudflare.com/hc/en-us/articles/202775670-How-Do-I-Tell-Cloudflare-What-to-Cache-), so by default this will override cache behavior for static files. If you wish to cache non-static assets, you will need to set a [Cache Level of Cache Everything](https://support.cloudflare.com/hc/en-us/articles/200172266-What-do-the-custom-caching-options-mean-in-Page-Rules-) using a Page Rule._
 


### PR DESCRIPTION
Companion PR to <https://github.com/cloudflare/workers-docs/issues/655>

This PR Updates documentation about cache keys to note that the current key format must be a valid URL.