### PR TITLE
Add development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ npm test
 
 ## Publishing
 
-To publish to staging:
+To publish to developement environment (which is protected by access at dev.bigfluffycloudflare.com/workers) run:
 
 ```
-npm run publish staging
+npm run publish dev
 ```
 
 # Releasing

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm test
 
 ## Publishing
 
-To publish to developement environment (which is protected by access at dev.bigfluffycloudflare.com/workers) run:
+To publish to development environment (which is protected by access at dev.bigfluffycloudflare.com/workers) run:
 
 ```
 npm run publish dev

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -22,3 +22,10 @@ name = "staging"
 zone_id = "8703d409e5c1c580aeee02b98f9fd448"
 route = "https://staging.bigfluffycloudflare.com/workers*"
 
+# Developement for testing 
+[env.dev]
+account_id = "95e065d2e3f97a1e50bae58aea71df6d"
+name = "dev"
+zone_id = "8703d409e5c1c580aeee02b98f9fd448"
+route = "https://dev.bigfluffycloudflare.com/workers*"
+


### PR DESCRIPTION
I was working on Gatsby rewrite and needed to publish to test, but didn't want to disturb staging while others are reviewing. 

This allows us to have a developer environment that is not staging for locally developing. It's behind access