### PR TITLE
Update references to cacheKey for Request constructor only.

### DIFF
--- a/content/archive/reference/cache-api.md
+++ b/content/archive/reference/cache-api.md
@@ -207,17 +207,17 @@ async function handleRequest(event) {
     url.pathname = "/posts" + url.pathname + hash
 
     // Convert to a GET to be able to cache
-    let cacheKey = new Request(url, {headers: request.headers, method: 'GET'})
+    let getRequest = new Request(url, {headers: request.headers, method: 'GET'})
 
     let cache = caches.default
     //try to find the cache key in the cache
-    response = await cache.match(cacheKey)
+    response = await cache.match(getRequest)
 
     // otherwise, fetch from origin
     if (!response) {
       // makes POST to the origin
       response = await fetch(request.url, newRequest)
-      event.waitUntil(cache.put(cacheKey, response.clone()))
+      event.waitUntil(cache.put(getRequest, response.clone()))
     }
   } else {
     response = await fetch(request) 

--- a/content/tutorials/build-a-todo-list/_index.md
+++ b/content/tutorials/build-a-todo-list/_index.md
@@ -414,9 +414,9 @@ One interesting and fairly trivial addition is implementing per-user caching. Of
 
 ```js
 const ip = request.headers.get('CF-Connecting-IP')
-const cacheKey = `data-${ip}`
+const myKey = `data-${ip}`
 const getCache = key => TODOS.get(key)
-getCache(cacheKey)
+getCache(myKey)
 ```
 
 One more deploy of our Workers project, and we have a full todo list application, with per-user functionality, served at the edge!
@@ -513,11 +513,11 @@ const getCache = key => TODOS.get(key)
 
 async function getTodos(request) {
   const ip = request.headers.get('CF-Connecting-IP')
-  const cacheKey = `data-${ip}`
+  const myKey = `data-${ip}`
   let data
-  const cache = await getCache(cacheKey)
+  const cache = await getCache(myKey)
   if (!cache) {
-    await setCache(cacheKey, JSON.stringify(defaultData))
+    await setCache(myKey, JSON.stringify(defaultData))
     data = defaultData
   } else {
     data = JSON.parse(cache)
@@ -531,10 +531,10 @@ async function getTodos(request) {
 async function updateTodos(request) {
   const body = await request.text()
   const ip = request.headers.get('CF-Connecting-IP')
-  const cacheKey = `data-${ip}`
+  const myKey = `data-${ip}`
   try {
     JSON.parse(body)
-    await setCache(cacheKey, body)
+    await setCache(myKey, body)
     return new Response(body, { status: 200 })
   } catch (err) {
     return new Response(err, { status: 500 })


### PR DESCRIPTION
Incorporating [suggestions form Harris](https://github.com/cloudflare/workers-docs/issues/655#issuecomment-590481653) 

References to cacheKey should refer exclusively to the Request constructor's option.

In this PR I chose the name myKey based on seeing a similar key name elsewhere in the repo. I chose getRequest based on the comment just above the change. I'm happy to swap them for whatever names the maintainers prefer.

Supersedes <https://github.com/cloudflare/workers-docs/pull/656>
Resolves <https://github.com/cloudflare/workers-docs/issues/655>