### PR TITLE
markdown to render ids in headers

### DIFF
--- a/src/content/tooling/wrangler/commands.md
+++ b/src/content/tooling/wrangler/commands.md
@@ -17,7 +17,7 @@ weight: 2
 - [🤫 `secret`](#secret)
 
 
-### 👯 `generate`
+###  generate
 
   Scaffold a project, including boilerplate for a Rust library and a Cloudflare Worker.
   You can pass a name and template to this command optionally.
@@ -33,7 +33,7 @@ weight: 2
   - `type`: defaults to ["webpack"](/tooling/wrangler/webpack)
   - `--site`: generates a [Workers Site](/sites) from an existing static site
 
-### 📥 `init`
+###  init
 
   Creates a skeleton `wrangler.toml` in an existing directory. This can be used as an alternative to `generate` if you prefer to clone a repository yourself.
 
@@ -47,14 +47,14 @@ weight: 2
   - `type`: defaults to ["webpack"](/tooling/wrangler/webpack).
   - `--site`: generates a [Workers Site](/sites) from an existing static site
 
-### 🦀⚙️ `build`
+### build
 
   Build your project. This command looks at your `wrangler.toml` file and runs the build steps associated
   with the `"type"` declared there.
 
   Additionally, you can build different environments. This is useful if you have different builds for different environments, but typically isn't needed. For more information see the [environments documentation](/tooling/wrangler/configuration/environments).
 
-### 🔧 `config`
+### config
 
   Configure your global Cloudflare user. This is an interactive command that will prompt you for your API token:
 
@@ -75,7 +75,7 @@ weight: 2
 
   You can also [use environment variables](/tooling/wrangler/configuration/) to configure these values.
 
-### ☁️ 🆙 `publish`
+### publish
 
   Publish your Worker to Cloudflare. Several keys in your `wrangler.toml` determine whether you are publishing to a workers.dev subdomain or your own registered domain, proxied through Cloudflare.
 
@@ -121,7 +121,7 @@ If you would like to publish to your own domain, you will need to specify these 
 
 If you would like to be able to publish your code to multiple places, please see the documentation for [environments](/tooling/wrangler/configuration/environments).
 
-### 🔬 `preview`
+### preview
 
   Preview your project using the [Cloudflare Workers preview service](https://cloudflareworkers.com/).
 
@@ -173,10 +173,10 @@ If you would like to be able to publish your code to multiple places, please see
 
   If you're using WSL 2, you will need to install `wsl-open` via their [standalone method](https://github.com/4U6U57/wsl-open#standalone) rather than through `npm`. This is because their npm package has not yet been updated with WSL 2 support.
 
-### 🗂️ `kv`
+### kv
 
   Interact with your Cloudflare Workers KV store. [Check out the docs.](/tooling/wrangler/kv_commands)
 
-### 🤫 `secret`
+### secret
 
   Interact with your secrets. [Check out the docs.](/tooling/wrangler/secrets)

--- a/src/templates/markdownTemplate.tsx
+++ b/src/templates/markdownTemplate.tsx
@@ -14,6 +14,24 @@ type markdownBaseProps = {
   data: { mdx: markdownRemarkResult }
   pageContext: markdownPageContext
 }
+const getChildrenAsString = (
+  props: React.HtmlHTMLAttributes<HTMLHeadingElement>
+) => {
+  if (typeof props.children === 'string') {
+    return props.children.replace(/(\s|\.)+/g, '-').toLowerCase()
+  }
+  // TODO if we'd like headers with children to still have IDs
+  // then we can test and uncomment this code
+  // if (props.children) {
+  //   const textChild = Object.keys(props.children).map(key => {
+  //     let child = props.children[key]
+  //     return typeof child === 'string' ? child : ''
+  //   })[0]
+  //   return textChild ? textChild.replace(/\s+/g, '-').toLowerCase() : ''
+  // }
+
+  return ''
+}
 const components = {
   Gallery,
   a: (props: any) => {
@@ -21,6 +39,18 @@ const components = {
   },
   img: (props: any) => {
     return <Image src={props.src} {...props} />
+  },
+  h1: (props: React.HtmlHTMLAttributes<HTMLHeadingElement>) => {
+    return <h1 id={getChildrenAsString(props)} {...props} />
+  },
+  h2: (props: React.HtmlHTMLAttributes<HTMLHeadingElement>) => {
+    return <h2 id={getChildrenAsString(props)} {...props} />
+  },
+  h3: (props: React.HtmlHTMLAttributes<HTMLHeadingElement>) => {
+    return <h3 id={getChildrenAsString(props)} {...props} />
+  },
+  h4: (props: React.HtmlHTMLAttributes<HTMLHeadingElement>) => {
+    return <h4 id={getChildrenAsString(props)} {...props} />
   },
 }
 const MarkdownTemplate: React.FC<markdownBaseProps> = ({


### PR DESCRIPTION
Note: For wrangler commands it was really tricky getting the emoji and code as an id, so I simply removed them for now

fixes https://github.com/cloudflare/workers-docs/issues/677