### PR TITLE
markdownify template description

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4360,6 +4360,11 @@
       "resolved": "https://registry.npmjs.org/@types/lunr/-/lunr-2.3.2.tgz",
       "integrity": "sha512-zcUZYquYDUEegRRPQtkZ068U9CoIjW6pJMYCVDRK25r76FEWvMm1oHqZQUfQh4ayIZ42lipXOpXEiAtGXc1XUg=="
     },
+    "@types/marked": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.7.3.tgz",
+      "integrity": "sha512-WXdEKuT3azHxLTThd5dwnpLt2Q9QiC8iKj09KZRtVqro3pX8hhY+GbD8FZOae6SBBEJ22yKJn3c7ejL0aucAcA=="
+    },
     "@types/mdx-js__react": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@types/mdx-js__react/-/mdx-js__react-1.5.0.tgz",
@@ -15770,6 +15775,11 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
       "integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q=="
+    },
+    "marked": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.0.tgz",
+      "integrity": "sha512-MyUe+T/Pw4TZufHkzAfDj6HarCBWia2y27/bhuYkTaiUnfDYFnCP3KUN+9oM7Wi6JA2rymtVYbQu3spE0GCmxQ=="
     },
     "matcher": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@mdx-js/react": "^1.5.4",
     "@types/lodash.debounce": "^4.0.6",
     "@types/lunr": "^2.3.2",
+    "@types/marked": "^0.7.3",
     "@types/mdx-js__react": "^1.5.0",
     "@types/react-copy-to-clipboard": "^4.3.0",
     "gatsby": "^2.15.29",
@@ -39,6 +40,7 @@
     "gatsby-source-rest-api": "^0.2.2",
     "lodash.debounce": "^4.0.8",
     "lunr": "^2.3.8",
+    "marked": "^0.8.0",
     "prop-types": "^15.7.2",
     "react": "^16.10.2",
     "react-copy-to-clipboard": "^5.0.2",
@@ -58,9 +60,9 @@
     "@types/react": "^16.9.17",
     "@types/react-dom": "^16.9.1",
     "@types/react-helmet": "^5.0.14",
+    "ava": "^2.4.0",
     "glob": "^7.1.6",
-    "prettier": "^1.18.2",
-    "ava": "^2.4.0"
+    "prettier": "^1.18.2"
   },
   "keywords": [
     "gatsby"

--- a/src/components/TemplateGallery/Boilerplate.tsx
+++ b/src/components/TemplateGallery/Boilerplate.tsx
@@ -2,6 +2,7 @@ import { restApiTemplate } from '../../types/restApiTemplates'
 import React from 'react'
 import { Link, Src } from '../../components/Link'
 import { useRestApiTemplates } from '../../hooks/useMarkdownRemark'
+import marked from 'marked'
 type boilerplateProps = restApiTemplate & {
   page_url?: string
 }
@@ -40,8 +41,7 @@ export const Boilerplate: React.FC<boilerplateProps> = props => {
         <h2>{title}</h2>
         <img src={Src('/templates/media/right-arrow.svg')} alt="right arrow" />
       </Link>
-      {/* Todo may need mardownify */}
-      <p>{description}</p>
+      <p dangerouslySetInnerHTML={{ __html: marked(description) }} />
       <div className="copy-group">
         <div className="copy-step">
           <img src={Src('/templates/media/terminal.svg')} alt="terminal icon" />

--- a/src/components/TemplateGallery/Snippet.tsx
+++ b/src/components/TemplateGallery/Snippet.tsx
@@ -4,6 +4,7 @@ type snippetProps = Partial<restApiTemplate> & {
   page_url?: string
 }
 import { useRestApiTemplates } from '../../hooks/useMarkdownRemark'
+import marked from 'marked'
 export const Snippet: React.FC<snippetProps> = props => {
   const { allRestApiTemplates } = useRestApiTemplates()
   const getSnippet = (id: string) => {
@@ -36,10 +37,9 @@ export const Snippet: React.FC<snippetProps> = props => {
 
       <a href={page_url}>
         <h2>{title}</h2>
-        <img src={'/workers/templates/media/right-arrow.svg'} alt="right arrow"/>
+        <img src={'/workers/templates/media/right-arrow.svg'} alt="right arrow" />
       </a>
-      {/* might neded to markdownify */}
-      <p>{description}</p>
+      {description ? <p dangerouslySetInnerHTML={{ __html: marked(description) }} /> : ''}
       <div className="copy-group">
         <div className="copy-step">
           <img src={'/workers/templates/media/file.svg'} alt="file icon" />

--- a/src/components/TemplateGallery/TemplatePage.tsx
+++ b/src/components/TemplateGallery/TemplatePage.tsx
@@ -4,6 +4,9 @@ import CopyToClipboard from 'react-copy-to-clipboard'
 import { Helmet } from 'react-helmet'
 
 import { restApiTemplate } from '../../types/restApiTemplates'
+import marked from 'marked'
+import { MDXProvider } from '@mdx-js/react'
+import { MDXRenderer } from 'gatsby-plugin-mdx'
 type templateProps = {
   id: string
   data: restApiTemplate
@@ -85,7 +88,7 @@ const TemplatePage: React.FC<templateProps> = ({ id, data }) => {
       </Helmet>
       <figure className="template-page" id={id}>
         <Link to={'/templates'} {...{ className: 'back' }}>
-          <img src={Src('/templates/media/left-arrow.svg')} alt="left arrow icon"/>
+          <img src={Src('/templates/media/left-arrow.svg')} alt="left arrow icon" />
           Template Gallery
         </Link>
         <div className="grid-3-noBottom_xs-5">
@@ -98,7 +101,10 @@ const TemplatePage: React.FC<templateProps> = ({ id, data }) => {
                   const demo = demos[key]
                   return demo ? (
                     <Link key={demo.url} to={demo.url}>
-                      <img src={Src('/templates/media/external-link.svg')} alt="external link icon" />
+                      <img
+                        src={Src('/templates/media/external-link.svg')}
+                        alt="external link icon"
+                      />
                       <span>{demo.text}</span>
                     </Link>
                   ) : null
@@ -111,7 +117,7 @@ const TemplatePage: React.FC<templateProps> = ({ id, data }) => {
             <div className="headline">
               <hr />
               {/* Might need to markdownify */}
-              <p>{description}</p>
+              <span dangerouslySetInnerHTML={{ __html: marked(description) }} />
               <div className="tag-group">
                 {tags
                   ? tags.map(tag => (
@@ -141,7 +147,11 @@ const TemplatePage: React.FC<templateProps> = ({ id, data }) => {
                 <div className="copy-group">
                   <span className="copy">wrangler generate my-app {repository_url}</span>
                   <CopyToClipboard text={'wrangler generate my-app ' + repository_url}>
-                    <img className="copy-trigger" src={Src('/svg/copy-box.svg')} alt="copy box icon" />
+                    <img
+                      className="copy-trigger"
+                      src={Src('/svg/copy-box.svg')}
+                      alt="copy box icon"
+                    />
                   </CopyToClipboard>
                 </div>
                 <span>


### PR DESCRIPTION
Links and other markdown will now render as html for gallery and template pages

<img width="430" alt="Screen Shot 2020-03-09 at 6 09 08 PM" src="https://user-images.githubusercontent.com/7578652/76264910-1bf23880-6231-11ea-9d3a-787f4815f7dc.png">


fixes https://github.com/cloudflare/workers-docs/issues/673
fixes https://github.com/cloudflare/workers-docs/issues/679