### PR TITLE
Remove option to pass in share_url

### DIFF
--- a/src/components/TemplateGallery/Boilerplate.tsx
+++ b/src/components/TemplateGallery/Boilerplate.tsx
@@ -3,9 +3,7 @@ import React from 'react'
 import { Link, Src } from '../../components/Link'
 import { useRestApiTemplates } from '../../hooks/useMarkdownRemark'
 import marked from 'marked'
-type boilerplateProps = restApiTemplate & {
-  page_url?: string
-}
+type boilerplateProps = restApiTemplate
 export const Boilerplate: React.FC<boilerplateProps> = props => {
   const { allRestApiTemplates } = useRestApiTemplates()
   const getBoilerplate = (id: string) => {
@@ -17,14 +15,10 @@ export const Boilerplate: React.FC<boilerplateProps> = props => {
     }
     return boilerplate
   }
-  let { endpointId, description, title, share_url, tags, repository_url } = props.description
+  let { endpointId, description, title, tags, repository_url } = props.description
     ? props
     : getBoilerplate(props.endpointId || '')
-  let { page_url } = props
   const template_page = Src('/templates/pages/' + endpointId)
-
-  page_url = share_url ? share_url : template_page // TODO may need to consider tutorial? // TODO may need to consider tutorial?
-  page_url = Src(page_url)
 
   // TODO use regex to make sure leading slash
   return (
@@ -37,7 +31,7 @@ export const Boilerplate: React.FC<boilerplateProps> = props => {
           </button>
         ))}
       </div>
-      <Link to={page_url}>
+      <Link to={template_page}>
         <h2>{title}</h2>
         <img src={Src('/templates/media/right-arrow.svg')} alt="right arrow" />
       </Link>

--- a/src/components/TemplateGallery/Snippet.tsx
+++ b/src/components/TemplateGallery/Snippet.tsx
@@ -1,10 +1,10 @@
 import { restApiTemplate, allRestApiTemplates } from '../../types/restApiTemplates'
 import React from 'react'
-type snippetProps = Partial<restApiTemplate> & {
-  page_url?: string
-}
+type snippetProps = Partial<restApiTemplate>
+
 import { useRestApiTemplates } from '../../hooks/useMarkdownRemark'
 import marked from 'marked'
+import { Src } from '../Link'
 export const Snippet: React.FC<snippetProps> = props => {
   const { allRestApiTemplates } = useRestApiTemplates()
   const getSnippet = (id: string) => {
@@ -17,13 +17,11 @@ export const Snippet: React.FC<snippetProps> = props => {
     return snippet
   }
 
-  let { endpointId, code, description, title, share_url, tags } = props.description
+  let { endpointId, code, description, title, tags } = props.description
     ? props
     : getSnippet(props.endpointId || '')
-  let { page_url } = props
-  const template_page = '/workers/templates/pages/' + endpointId
-  page_url = share_url ? '/' + share_url : template_page // TODO may need to consider tutorial?
-  page_url = page_url
+  const template_page = Src('/workers/templates/pages/' + endpointId)
+
   return (
     <figure className="template-card snippet" id={endpointId}>
       <div className="tag-group">
@@ -35,7 +33,7 @@ export const Snippet: React.FC<snippetProps> = props => {
         ))}
       </div>
 
-      <a href={page_url}>
+      <a href={template_page}>
         <h2>{title}</h2>
         <img src={'/workers/templates/media/right-arrow.svg'} alt="right arrow" />
       </a>


### PR DESCRIPTION
When I was developing on the Gallery, I wanted to allow snippets to be able to pass in custom pages to link to (e.g. debugging template could point to `/about/tips/debugging`) but this actually never worked. 

This PR makes it to where the Gallery will only link to `templates/pages/:id` which that page will always exist