### PR TITLE
Add repository dispatch to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  repository_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
This PR adds the `repository_dispatch` event to our deploy workflow in `.github/workflows/deploy.yml`. During a production outage this evening, I was unable to manually kick off a new deploy: adding this will allow us to make a webhook request and deploy the docs in the future.