### PR TITLE
Fix code example typo in environment-variables.md

### DIFF
--- a/src/content/reference/apis/environment-variables.md
+++ b/src/content/reference/apis/environment-variables.md
@@ -12,7 +12,7 @@ Once a text variable is uploaded via [wrangler](/tooling/wrangler/configuration)
 ```
 if (ENVIRONMENT === "staging") {
   // staging-specific code
-} else if (ENVIRONMENT === "production" {
+} else if (ENVIRONMENT === "production") {
   // production-specific code
 }
 ```


### PR DESCRIPTION
Adds missing `)` in code example.