### PR TITLE
Fix syntax on HTMLRewriter example

### DIFF
--- a/src/content/reference/apis/html-rewriter.md
+++ b/src/content/reference/apis/html-rewriter.md
@@ -24,7 +24,9 @@ The `HTMLRewriter` class allows developers to build comprehensive and expressive
 The `HTMLRewriter` class should be instantiated once in your Workers script, with a number of handlers attached using the `on` and `onDocument` functions:
 
 ```js
-new HTMLRewriter.on('*', new ElementHandler()).onDocument(new DocumentHandler())
+new HTMLRewriter()
+  .on('*', new ElementHandler())
+  .onDocument(new DocumentHandler())
 ```
 
 ## Selectors


### PR DESCRIPTION
adds the correct format for initializing the htmlrewriter class at the beginning of the htmlrewriter docs - this has been bugging me for like a month and i haven't gotten around to submitting a PR - my bad!!