### PR TITLE
Fix link

### DIFF
--- a/src/content/index.mdx
+++ b/src/content/index.mdx
@@ -60,7 +60,7 @@ import { Boilerplate } from "../components/TemplateGallery/Boilerplate"
 <h2>Reference</h2>
 <section class="reference-links">
   <div>
-    <a href="/reference/runtime/apis">Runtime APIs</a>
+    <a href="/reference/apis">Runtime APIs</a>
     <p>Global variables immediately available in your code</p>
   </div>
   <div>


### PR DESCRIPTION
This link URL is a server-side redirect, but the client-side JS doesn't know that and shows a 404. Updated the link to the redirect target.