### PR TITLE
Fix a typo in WordPress

### DIFF
--- a/src/content/tutorials/_index.md
+++ b/src/content/tutorials/_index.md
@@ -8,6 +8,6 @@ weight: 3
 - [Build a To-Do List With KV](/tutorials/build-a-todo-list)
 - [Build a Serverless Function](/tutorials/build-a-serverless-function)
 - [Deploy a React App](/tutorials/deploy-a-react-app)
-- [Hosting Static Wordpress Sites](/tutorials/hosting-static-wordpress-sites)
+- [Hosting Static WordPress Sites](/tutorials/hosting-static-wordpress-sites)
 - [Configure Your CDN](/tutorials/configure-your-cdn)
 - [Managing Multiple Projects with Lerna](/tutorials/manage-projects-with-lerna)


### PR DESCRIPTION
Very small 1 alphabet change. 
Capitalized P in WordPress :)