### PR TITLE
Fix typo in fetch-event.md

### DIFF
--- a/src/content/reference/apis/fetch-event.md
+++ b/src/content/reference/apis/fetch-event.md
@@ -3,7 +3,7 @@ title: fetchEvent
 weight: 3
 ---
 
-The event type for HTTP requests dispatched to a Worker (i.e the`Object` passed through as `'fetch'` in `addEventListener('fetch', event => {…})`).
+The event type for HTTP requests dispatched to a Worker (i.e the `Object` passed through as `event` in `addEventListener('fetch', event => {…})`).
 
 If multiple event listeners are registered, when an event handler does not call `respondWith()` the runtime delivers the event to the next registered event handler.
 


### PR DESCRIPTION
This documentation details the `event` Object, not the `'fetch'` string. Also, add a space where it was missing.