### PR TITLE
Minor changes to API Token and Global API Key Sections in the Quick Start

### DIFF
--- a/src/content/quickstart/_index.md
+++ b/src/content/quickstart/_index.md
@@ -199,13 +199,14 @@ For workers.dev domains, you will just need the Account ID:
 
 ## API Token
 
-1. Click **Get API Token** below the _API_ section to jump to your _Profile_ page.
-2. Click **Create Token** and select the **Start with Template** radio button. Select the **Edit Cloudflare Workers** template.
-3. Fill out the rest of the fields and then click **Continue to Summary**, where you can click **Create Token** and issue your token for use.
+1. Click **Get your API token** below the _CLI and API_ section to jump to your _Profile_ page.
+2. Click **Create Token**. 
+3. Under the _API token templates_ section, find the **Edit Cloudflare Workers** template and click **Use template**.
+4. Fill out the rest of the fields and then click **Continue to Summary**, where you can click **Create Token** and issue your token for use.
 
 ## Global API Key
 
-1. Click **Get API Token** below the _API_ section to jump to your _Profile_ page.
+1. Click **Get your API token** below the _CLI and API_ section to jump to your _Profile_ page.
 2. Scroll to _API Keys_, and click **View** to copy your Global API Key **\***.
 
 **\* IMPORTANT: Treat your Global API Key like a password!**


### PR DESCRIPTION
Hi! I recently used this [Quick Start](https://developers.cloudflare.com/workers/quickstart) to learn about Cloudflare Worker's for the SWE internship application. 

The steps under the  **API Token** and the **Global API Key** section were a little off compared to the actual site's workflow, so I thought I would submit a PR. Hopefully it's helpful! :sparkles: 