### PR TITLE
IPv6 limitation off Subrequest fetches on preview tool.

### DIFF
--- a/src/content/tooling/playground.md
+++ b/src/content/tooling/playground.md
@@ -87,7 +87,7 @@ While the preview tool is powerful in development, the tool must run as a mock p
 The key differences of the previewer versus a live Workers script are:
 
 - Subrequests ( i.e. fetches inside your Workers script) that call the same hostname as the original request will run in the previewer as an external request (i.e. goes back to the front line of Cloudflare), as those subrequests in production will go directly to the origin.
-- Subrequest fetches to IPv6-only hosts are not supported.
+-  `fetch` can only connect to IPv4 addresses in the playground thus, IPv6-only hosts are not supported.
 - The output of `console.log` acts as a no-op in production.
 - Not all [APIs](/reference/runtime/apis) are available in the previewer that are in production. Cloudflare Edge dependent features particularly (e.g. [Cache API](/reference/apis/cache)) will _not_ work in the previewer.
 - If the tested zone has Cloudflare security features set that would block our preview service, such as "Block by country", then one would receive an error message `Sorry, you've been blocked`. To work around this, use the [fiddle service](https://cloudflareworkers.com), or whitelist [Google Cloud IPs](http://ueen.net/google_cloud_ip.txt)\* to preview scripts.

--- a/src/content/tooling/playground.md
+++ b/src/content/tooling/playground.md
@@ -87,7 +87,7 @@ While the preview tool is powerful in development, the tool must run as a mock p
 The key differences of the previewer versus a live Workers script are:
 
 - Subrequests ( i.e. fetches inside your Workers script) that call the same hostname as the original request will run in the previewer as an external request (i.e. goes back to the front line of Cloudflare), as those subrequests in production will go directly to the origin.
-- Subrequest fetches to IPv6 only hosts are not supported.
+- Subrequest fetches to IPv6-only hosts are not supported.
 - The output of `console.log` acts as a no-op in production.
 - Not all [APIs](/reference/runtime/apis) are available in the previewer that are in production. Cloudflare Edge dependent features particularly (e.g. [Cache API](/reference/apis/cache)) will _not_ work in the previewer.
 - If the tested zone has Cloudflare security features set that would block our preview service, such as "Block by country", then one would receive an error message `Sorry, you've been blocked`. To work around this, use the [fiddle service](https://cloudflareworkers.com), or whitelist [Google Cloud IPs](http://ueen.net/google_cloud_ip.txt)\* to preview scripts.

--- a/src/content/tooling/playground.md
+++ b/src/content/tooling/playground.md
@@ -87,6 +87,7 @@ While the preview tool is powerful in development, the tool must run as a mock p
 The key differences of the previewer versus a live Workers script are:
 
 - Subrequests ( i.e. fetches inside your Workers script) that call the same hostname as the original request will run in the previewer as an external request (i.e. goes back to the front line of Cloudflare), as those subrequests in production will go directly to the origin.
+- Subrequest fetches to IPv6 only hosts are not supported.
 - The output of `console.log` acts as a no-op in production.
 - Not all [APIs](/reference/runtime/apis) are available in the previewer that are in production. Cloudflare Edge dependent features particularly (e.g. [Cache API](/reference/apis/cache)) will _not_ work in the previewer.
 - If the tested zone has Cloudflare security features set that would block our preview service, such as "Block by country", then one would receive an error message `Sorry, you've been blocked`. To work around this, use the [fiddle service](https://cloudflareworkers.com), or whitelist [Google Cloud IPs](http://ueen.net/google_cloud_ip.txt)\* to preview scripts.


### PR DESCRIPTION
Refers to an issue raised in the [Cloudflare Community](https://community.cloudflare.com/t/fetch-in-workers-cannot-connect-ipv6-hosts/168208) and related to ticket **1877587** CF support.