### PR TITLE
Remove overflow hidden to fix sidebar badge styling

### DIFF
--- a/src/content/static/css/theme.css
+++ b/src/content/static/css/theme.css
@@ -1750,7 +1750,6 @@ select[multiple='multiple']:focus {
 }
 #sidebar ul li a span {
   text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
   display: block;
   padding-right: 4px;


### PR DESCRIPTION
Fixes sidebar badge styling

<img width="273" alt="Screenshot 2020-05-09 at 11 56 08 PM" src="https://user-images.githubusercontent.com/6488520/81481954-483a2d80-9251-11ea-8996-db57548c66ba.png">

