### PR TITLE
Update initial definition of createTodo

### DIFF
--- a/workers-docs/src/content/tutorials/build-a-todo-list/_index.md
+++ b/workers-docs/src/content/tutorials/build-a-todo-list/_index.md
@@ -279,6 +279,11 @@ Given that input and button, we can add a corresponding JavaScript function to w
 var createTodo = function() {
   var input = document.querySelector('input[name=name]')
   if (input.value.length) {
+    todos = [].concat(todos, {
+      id: todos.length + 1,
+      name: input.value,
+      completed: false,
+    })  
     fetch('/', {
       method: 'PUT',
       body: JSON.stringify({ todos: todos }),


### PR DESCRIPTION
`createTodo` needs to send the full list of task items in the PUT request. 
This is already clear lower down in the documentation (33 lines later in this .md file) , when `concat` is used to append the new task to the existing list of tasks.