### PR TITLE
Fetch docs reorg and content refresh

### DIFF
--- a/workers-docs/src/content/reference/_index.md
+++ b/workers-docs/src/content/reference/_index.md
@@ -7,8 +7,11 @@ weight: 7
 ### Runtime APIs
 
 - [Web Standards](/reference/apis/standard)
-- [Fetch](/reference/apis/fetch)
+- [fetch()](/reference/apis/fetch)
 - [FetchEvent](/reference/apis/fetch-event)
+- [addEventListener](/reference/apis/addEventListener)
+- [Request](/reference/apis/request)
+- [Response](/reference/apis/response)
 - [Cache](/reference/apis/cache)
 - [Streams](/reference/apis/streams)
 - [Encoding](/reference/apis/encoding)

--- a/workers-docs/src/content/reference/apis/addEventListener.md
+++ b/workers-docs/src/content/reference/apis/addEventListener.md
@@ -1,0 +1,16 @@
+---
+title: addEventListener
+weight: 3
+---
+
+To define triggers for a Worker script to execute. Currently the only event type supported is [`FetchEvent`](/reference/apis/fetch-event).
+
+If multiple event listeners are registered, when an event handler does not call `respondWith()` the runtime delivers the event to the next registered event handler.
+
+## Usage
+
+```js
+addEventListener('fetch', event => {…})
+```
+
+`event` is of type [`FetchEvent`](/reference/apis/fetch-event)

--- a/workers-docs/src/content/reference/apis/fetch-event.md
+++ b/workers-docs/src/content/reference/apis/fetch-event.md
@@ -1,23 +1,34 @@
 ---
-title: fetchEvent
+title: FetchEvent
 weight: 3
 ---
 
-The event type for HTTP requests dispatched to a Worker (i.e the `Object` passed through as `event` in `addEventListener('fetch', event => {…})`).
+The event type for HTTP requests dispatched to a Worker (i.e the`Object` passed through as `event` in [`addEventListener`](/reference/apis/addEventListener).
 
-If multiple event listeners are registered, when an event handler does not call `respondWith()` the runtime delivers the event to the next registered event handler.
+## Usage
+
+```js
+addEventListener('fetch', (event) => {
+  event.respondWith(eventHandler(event))
+})
+```
 
 ### Properties
 
-- `type`: The type of event. Always = `fetch`.
+- `event.type: String`: The type of event. Always = `fetch`.
 
-- `request`: A [Request Object](/reference/apis/request) that represents the request triggering `FetchEvent`.
+- `event.request:`[`Request`](/reference/apis/request): The incoming HTTP request triggering `FetchEvent`.
 
 ### Methods
 
-- `passThroughOnException`: Cause the script to ["fail open"](https://community.microfocus.com/t5/Security-Blog/Security-Fundamentals-Part-1-Fail-Open-vs-Fail-Closed/ba-p/283747) unhandled exceptions. Instead of returning a runtime error response, the runtime proxies the request to its destination. To prevent JavaScript errors from causing entire requests to fail on uncaught exceptions, `passThroughOnException` causes the Worker script to act as if the exception wasn’t there. This allows the script to yield control to your origin server.
-- `respondWith`: Intercept the request and send a custom response.
-	If no event handler calls `respondWith()` the runtime attempts to proxy the request to the origin as if no Worker script intercepted.
-- `waitUntil`: Extend the lifetime of the event. Use this method to notify the runtime to wait for tasks, such as streaming and caching, that run longer than the usual time it takes to send a response. This is good for handling logging and analytics to third-party services, where you don't want to block the `response`.
+The `FetchEvent` lifecycle starts when a Workers script receives a request; this causes the Workers runtime to trigger a `fetch` event and creates a FetchEvent Object to pass to the first event handler in the Workers function registered for `'fetch'`. Then the event handler can use any of the following methods to control what happens next:
+
+- `event.respondWith(response:`[`Response`](/reference/apis/response)`| Promise <`[`Response`](/reference/apis/response)`> ): void`: Intercept the request and send a custom response.
+
+  _If no event handler calls `respondWith()` the runtime attempts to request the origin as if no Worker script exists. If no origin is setup (e.g. workers.dev sites), then the Workers script must call `respondWith()` for a valid response._
+
+- `event.passThroughOnException(): void`: Cause the script to ["fail open"](https://community.microfocus.com/t5/Security-Blog/Security-Fundamentals-Part-1-Fail-Open-vs-Fail-Closed/ba-p/283747) unhandled exceptions. Instead of returning a runtime error response, the runtime proxies the request to its destination. To prevent JavaScript errors from causing entire requests to fail on uncaught exceptions, `passThroughOnException` causes the Worker script to act as if the exception wasn’t there. This allows the script to yield control to your origin server.
+
+- `event.waitUntil(pro Promise < void > ): void`: Extend the lifetime of the event without blocking the `response` to the request. Use this method to notify the runtime to wait for tasks (e.g. logging,analytics to third-party services, streaming and caching) that run longer than the usual time it takes to send a response.
 
 To learn more about using the `FetchEvent`, see [FetchEvent LifeCycle](/about/tips/fetch-event-lifecycle).

--- a/workers-docs/src/content/reference/apis/fetch.md
+++ b/workers-docs/src/content/reference/apis/fetch.md
@@ -1,22 +1,40 @@
 ---
-title: fetch
+title: fetch()
 weight: 2
 ---
 
 ## Overview
 
-The [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) provides an interface for asyncronously fetching resources by providing a definition of a request and response. You will frequently find yourself interacting with request objects included as part of a [FetchEvent](/reference/apis/fetch-event), making your own requests using the global `fetch` method, and constructing your own responses.
-
-\*_Note: The Fetch API is only available inside of [the Request Context](/about/tips/request-context)._
+The [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) provides an interface for asyncronously fetching resources via HTTP requests inside of a Worker.
 
 ## Global
 
-The `fetch` method is implemented on the ServiceWorkerGlobalScope and matches the documentation [provided by MDN](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch)
+The `fetch` method is implemented on the ServiceWorkerGlobalScope. See [MDN documentation ](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch) for more information.
 
-## Headers
+_Note: Asynchronous tasks such as `fetch` are not executed at the top level in a Worker script and must be executed within a FetchEvent handler such as [`respondWith`](/reference/apis/fetch-event#methods). Learn more about [Request Contexts](/about/tips/request-context)._
 
-The Headers class matches the documentation [provided by MDN](https://developer.mozilla.org/en-US/docs/Web/API/Headers). If you expect Unicode values in your headers, URL or Base64 encode your header values before adding them to a Headers object.
+## Syntax
 
-#### Cloudflare Specific Headers
+`fetch(request:`[`Request`](/reference/apis/request)`| String, init?:`[`RequestInit`](/reference/apis/request)`) : Promise <`[`Response`](/reference/apis/response)`>`
 
-`CF-Connecting-IP`: The client IP
+Where request is the request or the string of the URL.
+
+## Usage
+
+```js
+addEventListener('fetch', (event) => {
+  event.respondWith(eventHandler(event))
+})
+// note: don’t use fetch here
+async function eventHandler(event) {
+  // fetch available here
+  const resp = await fetch(event.request)
+  return resp
+}
+```
+
+Examples:
+
+- [Fetch HTML](/templates/pages/fetch_html)
+- [Fetch JSON](/templates/pages/fetch_json)
+- [Cache using Fetch](/templates/pages/cache_ttl/)

--- a/workers-docs/src/content/reference/apis/request.md
+++ b/workers-docs/src/content/reference/apis/request.md
@@ -13,24 +13,25 @@ new Request(input [, init])
 
 #### Constructor Parameters
 
-- `input`: Either a USVString that contains the URL or an existing `Request` object. Note that the `url` property is immutable, so when [modifying a request](/templates/snippets/modify_req_props/) and changing the URL, you must pass the new URL in this parameter.
+- `input`: Either a USVString that contains the URL or an existing `Request` object. Note that the `url` property is immutable, so when [modifying a request](/templates/pages/modify_req_props/) and changing the URL, you must pass the new URL in this parameter.
 
 - `init` (optional): An options object that contains custom settings to apply to the request. Valid options are:
-  - `method`: The request method, such as `GET` or `POST`
-  - `headers`: A [Headers](/reference/apis/fetch#headers) object
-    - `body`: Any text to add to the request. **Note:** Requests using the `GET` or `HEAD` methods cannot have a body.
-    - `redirect`: The mode respected when the request is fetched. **Note:** default for requests generated from the incoming `fetchEvent` from the event handler is `manual`. Default for newly constructed Requests (i.e. `new Request(url)` ) is `follow`. Valid options:
-    - `follow`: If a redirect reponse is returned to the fetch, another fetch will be fired based on the `Location` header in the response until a non-redirect code is returned. (i.e. `await fetch(..)` could never return a `301` redirect)
-    - `manual`: redirect responses will return from a fetch
+  - `method: String`: The request method, such as `GET` or `POST`
+  - `headers: Headers`: The Headers class matches the documentation [provided by MDN](https://developer.mozilla.org/en-US/docs/Web/API/Headers). If you expect Unicode values in your headers, URL or Base64 encode your header values before adding them to a Headers object.
+    - `CF-Connecting-IP`: A Cloudflare specific header to specify the client IP
+  - `body: String`: Any text to add to the request. **Note:** Requests using the `GET` or `HEAD` methods cannot have a body.
+  - `redirect: Redirect`: The mode respected when the request is fetched. **Note:** default for requests generated from the incoming `fetchEvent` from the event handler is `manual`. Default for newly constructed Requests (i.e. `new Request(url)` ) is `follow`. Valid options:
+    - `follow: boolean`: If a redirect reponse is returned to the fetch, another fetch will be fired based on the `Location` header in the response until a non-redirect code is returned. (i.e. `await fetch(..)` could never return a `301` redirect)
+    - `manual: boolean`: redirect responses will return from a fetch
 
 ### Properties
 
-All properties of an incoming `Request` object (i.e. `event.request`) are read only. To [modify a request](/templates/snippets/modify_req_props/), you must create a new `Request` object and pass the options to modify to its [constructor](#Constructor).
+All properties of an incoming `Request` object (i.e. `event.request`) are read only. To [modify a request](/templates/pages/modify_req_props/), you must create a new `Request` object and pass the options to modify to its [constructor](#Constructor-parameters).
 
 - `body`: A simple getter that exposes a [`ReadableStream`](/reference/apis/streams) of the contents.
 - `bodyUsed`: A Boolean that declares if the body has been used in a response.
 - `cf`: An object that contains data provided by Cloudflare (see `request.cf` below).
-- `headers`: Contain the associated [`Headers`](/reference/apis/fetch#headers) object for the request.
+- `headers`: Contain the associated [`Headers`](/reference/apis/request#constructor-parameters) object for the request.
 - `method`: The request method, such as `GET` or `POST`, associated with the request.
 - `redirect`: The redirect mode to use: `follow` or `manual`.
 - `url`: Contains the URL of the request.
@@ -88,7 +89,7 @@ Cloudflare features all plans can set on outbound requests:
 
 A Workers script runs after Cloudflare security features, but before everything else. Therefore, a Workers script cannot affect the operation of security features (since they already finished), but it can affect other features, like Polish or ScrapeShield, or how Cloudflare caches the response.
 
-Updating the `cf` object is similar to [modifying a request](/templates/snippets/modify_req_props//). You can add the `cf` object to a `Request` by passing a custom object to [`fetch`](/reference/apis/fetch/). For examples on controlling cache settings see [the template](/templates/pages/cache_ttl).
+Updating the `cf` object is similar to [modifying a request](/templates/pages/modify_req_props/). You can add the `cf` object to a `Request` by passing a custom object to [`fetch`](/reference/apis/fetch/). For examples on controlling cache settings see [the template](/templates/pages/cache_ttl).
 
 ```javascript
 // Disable ScrapeShield for this request.

--- a/workers-docs/src/content/reference/apis/response.md
+++ b/workers-docs/src/content/reference/apis/response.md
@@ -21,14 +21,14 @@ new Response(body, init)
   - [`USVString`](https://developer.mozilla.org/en-US/docs/Web/API/USVString)
 - `init` (optional): An `options` object that contains custom settings to apply to the response. Valid options are:
   - `status`: The status code for the reponse, such as `200`.
-  - `statusText`: The status message associated with the status code, like, `OK`. 
-  - `headers`: Any headers to add to your response that are contained within a [`Headers`](/reference/apis/fetch#headers) object or object literal of [`ByteString`](https://developer.mozilla.org/en-US/docs/Web/API/ByteString) key/value pairs.
+  - `statusText`: The status message associated with the status code, like, `OK`.
+  - `headers`: Any headers to add to your response that are contained within a [`Headers`](/reference/apis/request#constructor-parameters) object or object literal of [`ByteString`](https://developer.mozilla.org/en-US/docs/Web/API/ByteString) key/value pairs.
 
 ### Properties
 
 - `body`: A simple getter used to expose a [`ReadableStream`](/reference/apis/streams) of the body contents.
 - `bodyUsed`: A Boolean value that declares if the body was used in a response.
-- `headers`: Contains the associated [Headers](/reference/apis/fetch#headers) object for the request.
+- `headers`: Contains the associated [Headers](/reference/apis/request#constructor-parameters) object for the request.
 - `ok`: Contains a Boolean value to indicate if the response was successful (status in the range 200-299).
 - `redirected`: Indicates if the response is the result of a redirect, that is, its URL list has more than one entry.
 - `status`: Contains the status code of the response (for example, `200` to indicate success).

--- a/workers-docs/workers-site/redirects/newDocs.js
+++ b/workers-docs/workers-site/redirects/newDocs.js
@@ -32,6 +32,7 @@ export const newDocsMap = new Map([
   ['/reference/runtime/apis/encoding', '/reference/apis/encoding'],
   ['/reference/runtime/apis/fetch-event', '/reference/apis/fetch-event'],
   ['/reference/runtime/apis/fetch', '/reference/apis/fetch'],
+  ['/reference/runtime/apis/fetch#headers', '/reference/apis/request#constructor-parameters'],
   ['/reference/runtime/apis/standard', '/reference/apis/standard'],
   ['/reference/runtime/apis/streams', '/reference/apis/streams'],
   ['/reference/runtime/apis/web-crypto', '/reference/apis/web-crypto'],


### PR DESCRIPTION
Worked with @1000hz on refreshing the content around fetch
- Made new addEventListener Section
- Add types syntax to fetch and fetchevent
- Move headers from fetch to Request page and set up appropriate redirects

Though this PR is most update version, it might be easier to visualize changes on content in google doc https://docs.google.com/document/d/16xufE2kyauGVn3Z_XOMXqV37wbFzgF2MFJKiL98CKBc/edit#

See version at https://dev.bigfluffycloudflare.com/workers/reference/apis/fetch/