### PR TITLE
Fix Tests with gatsby

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,3 +24,5 @@ jobs:
       run: yarn workspace cloudflare-workers-docs run build
     - name: Build Workers script
       run: yarn workspace cloudflare-workers-docs run worker-build
+    - name: Test Worker
+      run: yarn workspace cloudflare-workers-docs run worker-test

--- a/workers-docs/workers-site/src/mocks.js
+++ b/workers-docs/workers-site/src/mocks.js
@@ -2,8 +2,8 @@ const makeServiceWorkerEnv = require('service-worker-mock')
 
 const HASH = '123HASHBROWN'
 
-export const getEvent = request => {
-  const waitUntil = callback => {
+export const getEvent = (request) => {
+  const waitUntil = (callback) => {
     callback
   }
   return {
@@ -16,27 +16,28 @@ export const mockResponseRedirect = (url, code) =>
 
 export const mockKV = () => {
   const store = {
-    'templates/index.123HASHBROWN.html': 'templates/index.html',
-    'archive/recipes/pre-shared-keys/index.123HASHBROWN.html': 'archive/recipes/pre-shared-keys/index.html',
-    'archive/recipes/static-site/index.123HASHBROWN.html': `archive/recipes/static-site/index.html`,
+    'workers/templates/index.123HASHBROWN.html': 'workers/templates/index.html',
+    'workers/archive/recipes/pre-shared-keys/index.123HASHBROWN.html':
+      'workers/archive/recipes/pre-shared-keys/index.html',
+    'workers/archive/recipes/static-site/index.123HASHBROWN.html': `workers/archive/recipes/static-site/index.html`,
   }
   return {
-    get: path => store[path] || null,
+    get: (path) => store[path] || null,
   }
 }
 
 export const mockManifest = () => {
   return JSON.stringify({
-    'templates/index.html': `templates/index.${HASH}.html`,
-    'archive/recipes/pre-shared-keys/index.html': `archive/recipes/pre-shared-keys/index.${HASH}.html`,
-    'archive/recipes/static-site/index.html': `archive/recipes/static-site/index.${HASH}.html`,
+    'workers/templates/index.html': `workers/templates/index.${HASH}.html`,
+    'workers/archive/recipes/pre-shared-keys/index.html': `workers/archive/recipes/pre-shared-keys/index.${HASH}.html`,
+    'workers/archive/recipes/static-site/index.html': `workers/archive/recipes/static-site/index.${HASH}.html`,
   })
 }
 let cacheStore = {}
 export const mockCaches = () => {
   return {
     default: {
-      match: key => {
+      match: (key) => {
         return cacheStore[key] || null
       },
       put: (key, val) => {


### PR DESCRIPTION
When I implemented gatsby I didn't  run workers test since I wasn't changing the worker code. 
- change the mocks to have all files under `workers` dir because that how they are in `public` after gatsby is run
- Add test to CI so this doesn't happen again !

fixes #801 