### PR TITLE
Adds CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @cloudflare/workers-docs will be requested for
+# review when someone opens a pull request.
+
+*   @cloudflare/workers-docs


### PR DESCRIPTION
This specifies the @cloudflare/workers-docs team members as default reviewers