### PR TITLE
Add example for parsing tail output with jq

### DIFF
--- a/workers-docs/src/content/tooling/wrangler/commands.md
+++ b/workers-docs/src/content/tooling/wrangler/commands.md
@@ -164,6 +164,31 @@ If you would like to be able to publish your code to multiple places, please see
    * `--port PORT`: the port for your local log server
    * `--metrics-port PORT`: the port for serving [metrics information](https://developers.cloudflare.com/argo-tunnel/reference/arguments/#metrics) about the tunnel.
 
+#### Parsing with jq
+
+  tail outputs each request as a JSON object, making it difficult to read directly. Parsing with jq makes it easy to pretty-print with colorization as well as select and format output as needed.
+
+  For example, this jq command will flatten console.log() statements:
+
+  ```shell
+  wrangler tail | jq -r \
+       '# loop through all logs
+    .logs[] as $o |
+        # loop through messages in each log
+    $o.message[] as $m |
+        # set variables for clarity in format string
+    .event.request.headers."cf-connecting-ip" as $ip |
+    ($o.timestamp / 1000 | todate) as $datetime |
+        # Format the output
+    "[\($datetime)][\($o.level)][\($ip)] \($m)"'
+  ``` 
+  
+  Output:
+  ```
+  [2020-06-06T18:59:55Z][log][1.2.3.4] a log message
+  [2020-06-06T18:59:55Z][log][1.2.3.4] another log message
+  ```
+
 ### preview
 
   Preview your project using the [Cloudflare Workers preview service](https://cloudflareworkers.com/).

--- a/workers-docs/src/content/tooling/wrangler/commands.md
+++ b/workers-docs/src/content/tooling/wrangler/commands.md
@@ -173,14 +173,14 @@ If you would like to be able to publish your code to multiple places, please see
   ```shell
   wrangler tail | jq -r \
        '# loop through all logs
-    .logs[] as $o |
+    .logs[] as $log |
         # loop through messages in each log
-    $o.message[] as $m |
+    $log.message[] as $message |
         # set variables for clarity in format string
     .event.request.headers."cf-connecting-ip" as $ip |
-    ($o.timestamp / 1000 | todate) as $datetime |
+    ($log.timestamp / 1000 | todate) as $datetime |
         # Format the output
-    "[\($datetime)][\($o.level)][\($ip)] \($m)"'
+    "[\($datetime)][\($log.level)][\($ip)] \($message)"'
   ``` 
   
   Output:

--- a/workers-docs/src/content/tooling/wrangler/commands.md
+++ b/workers-docs/src/content/tooling/wrangler/commands.md
@@ -166,9 +166,9 @@ If you would like to be able to publish your code to multiple places, please see
 
 #### Parsing with jq
 
-  tail outputs each request as a JSON object, making it difficult to read directly. Parsing with jq makes it easy to pretty-print with colorization as well as select and format output as needed.
+`wrangler tail` outputs each request as a JSON object, making it difficult to read directly. Parsing requests with [jq](https://stedolan.github.io/jq) makes it easy to pretty-print with colorization, as well as select and format output as needed.
 
-  For example, this jq command will flatten console.log() statements:
+  For example, this `jq` command will flatten `console.log()` statements:
 
   ```shell
   wrangler tail | jq -r \


### PR DESCRIPTION
This pr is in response to [this wrangler issue](https://github.com/cloudflare/wrangler/issues/1368) showing that it isn't clear to everyone how to handle the JSON output from `wrangler tail`.

Instead of adding non-json output to `tail` as requested in the linked issue, I think adding documentation on how to parse output with jq would be a better solution.