### PR TITLE
Fix documentation of cache.put() with Vary header.

### DIFF
--- a/workers-docs/src/content/reference/apis/cache.md
+++ b/workers-docs/src/content/reference/apis/cache.md
@@ -44,7 +44,7 @@ cache.put(request, response)
 - `cache.put` throws an error if:
   - the `request` passed is a method other than `GET`
   - the `response` passed is a `status` of [`206 Partial Content`](https://httpstatuses.com/206)
-  - the `response` passed contains the header `Vary: _` (required by the Cache API specification)
+  - the `response` passed contains the header `Vary: *` (required by the Cache API specification)
 
 ##### Headers
 


### PR DESCRIPTION
It appears this was accidentally changed from `*` to `_` in this commit (which was intended to update formatting of `*`-delimited bullet lists):

https://github.com/cloudflare/workers-docs/commit/f6cc05508871ccf28baf489fca4c90fade64712c#diff-f957bc8a85ed81d23a2716190985ab84