### PR TITLE
add headers object in "Building a QR Code" section

### DIFF
--- a/workers-docs/src/content/tutorials/build-a-serverless-function/_index.md
+++ b/workers-docs/src/content/tutorials/build-a-serverless-function/_index.md
@@ -131,6 +131,7 @@ By default, the QR code is generated as a PNG. Construct a new instance of `Resp
 ```javascript
 const generate = async request => {
   // ...
+  const headers = { 'Content-Type': 'image/png' }
   return new Response(qr_png, { headers })
 }
 ```


### PR DESCRIPTION
in the section where the QR is generated and returned, the example sends the headers object back but doesn't show where it is defined. I added the definition of the object from the project repo