### PR TITLE
Prevent `</script`, `<!--` and `<script` injection into <script> tag

### DIFF
--- a/workers-docs/src/content/tutorials/build-a-jamstack-app/_index.md
+++ b/workers-docs/src/content/tutorials/build-a-jamstack-app/_index.md
@@ -217,8 +217,8 @@ async function handleRequest(request) {
   let data
 
   // Set data using cache or defaultData from previous section...
-
-  const body = html(JSON.stringify(data.todos))
+  // Escape JSON embedded into a <script> tag to prevent cross-site scripting.
+  const body = html(JSON.stringify(data.todos).replace(/</g, "\\u003c"))
   const response = new Response(body, {
     headers: { 'Content-Type': 'text/html' },
   })


### PR DESCRIPTION
Currently, the JSON obtained from Cloudflare Workers KV is embedded into a `script` element without any escaping. This allows for XSS and DoS via suitable injections:

* If the JSON data contains `</script>`, the `script` element will be closed and the rest of the JSON data will be executed as JavaScript in the context of the app. This allows for stored XSS in the context of the app.
* If the JSON data contains `<!--<script>`, the `script` element will not be closed by the first (and only) `</script>` end tag and will thus not be executed. This renders the app non-functional.

See [the HTML spec](https://www.w3.org/TR/html53/semantics-scripting.html#restrictions-for-contents-of-script-elements) for the list of substring that should be escaped in script elements.

With this commit, any `<` is rewritten as a JSON unicode escape, which prevents any kind of injection affecting the state of the HTML parser from within a JSON literal.