### PR TITLE
Avery/rebased preview namespaces

### DIFF
--- a/workers-docs/src/content/tooling/wrangler/commands.md
+++ b/workers-docs/src/content/tooling/wrangler/commands.md
@@ -145,6 +145,10 @@ From here you can send HTTP requests to `localhost:8787` and your Worker should 
 
 If you have feedback about `wrangler dev` or general questions, we will respond [here](https://github.com/cloudflare/wrangler/issues/1047).
 
+#### kv_namespaces
+
+If you are using [kv_namespaces](/tooling/wrangler/configuration/#kv_namespaces) with `wrangler dev`, you will need to specify a `preview_id` in your `wrangler.toml` before you can start the session. This is so that you do not accidentally write changes to your production namespace while you are developing. You may make `preview_id` equal to `id` if you would like to preview with your production namespace, but you should make sure that you are not writing things to KV that would break your production Worker.
+
 ### tail
 
 Starts a log tailing session for a deployed Worker.
@@ -180,7 +184,12 @@ wrangler preview [--watch] [--env $ENVIRONMENT_NAME] [ --url $URL] [$METHOD] [$B
 | `--env`   | Perform on a specific [environment](/tooling/wrangler/environments) specified as `$ENVIRONMENT_NAME` | Optional    | The top level environment                                    |
 | `--watch` | Enable live preview, so on changes Wrangler will continually update the preview service with the newest version of your project | Recommended | By default, `wrangler preview` will only bundle your project a single time. |
 | `$METHOD` | Type of request to preview your worker with (get, post)      | Optional    | GET                                                          |
-| `$BODY`   | Body string to post to your preview worker request. For example `wrangler preview post hello=hello` | Optional    | Null                                                         |
+| `$BODY`   | Body string to post to your preview worker request. For example `wrangler preview post hello=hello` | Optional    | Null    
+                                                     |
+
+#### kv_namespaces
+
+If you are using [kv_namespaces](/tooling/wrangler/configuration/#kv_namespaces) with `wrangler preview`, you will need to specify a `preview_id` in your `wrangler.toml` before you can start the session. This is so that you do not accidentally write changes to your production namespace while you are developing. You may make `preview_id` equal to `id` if you would like to preview with your production namespace, but you should make sure that you are not writing things to KV that would break your production Worker.
 
 #### Previewing on Windows Subsytem for Linux (WSL 1/2)
 

--- a/workers-docs/src/content/tooling/wrangler/configuration.md
+++ b/workers-docs/src/content/tooling/wrangler/configuration.md
@@ -93,6 +93,11 @@ name = "my-worker-dev"
 account_id = "12345678901234567890"
 zone_id = "09876543210987654321"
 route = "dev.example.com/*"
+kv_namespaces = [
+    { binding = "FOO", id = "b941aabb520e61dcaaeaa64b4d8f8358", preview_id = "03c8c8dd3b032b0528f6547d0e1a83f3" },
+    { binding = "BAR", id = "90e6f6abd5b4f981c748c532844461ae", preview_id = "e5011a026c5032c09af62c55ecc3f438" }
+]
+
 [site]
 bucket = "./public"
 entry-point = "workers-site"
@@ -138,7 +143,7 @@ Keys to configure per project in your `wrangler.toml`.
 | `routes`                          | Not Inherited                   | A list of routes you'd like to use your worker on. These follow exactly the same rules a `route`, but you can specify a list of them.<br />`routes = ["http://example.com/hello", "http://example.com/goodbye"]` | Optional \*\* |
 | `webpack_config`                  | Inherited                       | This is the path to a custom webpack configuration file for your worker. You must specify this field to use a custom webpack configuration, otherwise Wrangler will use a default configuration for you. You can read more [here](/tooling/wrangler/webpack). | Optional      |
 | [`vars`](#vars)                   | Not Inherited                   | An object containing text variables that can be directly accessed in a Worker script. See [environment variables](TODO:link). | Optional      |
-| [`kv_namespaces`](#kv_namespaces) | Not Inherited                   | These specify any [Workers KV](/reference/storage/) Namespaces you want to access from inside your Worker. Each namespace you include should have an entry in your `wrangler.toml` that includes: | Optional      |
+| [`kv_namespaces`](#kv_namespaces) | Not Inherited                   | These specify any [Workers KV](/reference/storage/) Namespaces you want to access from inside your Worker. | Optional      |
 | [`site`](#site)                   | Not Inherited                   | Determines the local folder to upload and serve from a Worker | Optional      |
 
 \* This key is optional if you are using only a [workers.dev](https://workers.dev) subdomain.
@@ -170,17 +175,18 @@ Usage:
 
 ```toml
 kv_namespaces = [
-    { binding = "FOO", id = "0f2ac74b498b48028cb68387c421e279" },
-    { binding = "BAR", id = "068c101e168d03c65bddf4ba75150fb0" }
+    { binding = "FOO", id = "0f2ac74b498b48028cb68387c421e279", preview_id = "6a1ddb03f3ec250963f0a1e46820076f" },
+    { binding = "BAR", id = "068c101e168d03c65bddf4ba75150fb0", preview_id = "fb69528dbc7336525313f2e8c3b17db0" }
 ]
 ```
 
 | Key       | Value                                                        | Required |
 | --------- | ------------------------------------------------------------ | -------- |
-| `binding` | After you've created a namespace, you must bind it to your Worker  so it is accessible from within the Worker script via a variable name you specify. | Yes      |
-| `id`      | The ID of the namespace you wish to attach to the Worker     | Yes      |
+| `binding`    | After you've created a namespace, you must bind it to your Worker  so it is accessible from within the Worker script via a variable name you specify. | Yes      |
+| `id`         | The ID of the namespace you wish to bind to the Worker's global scope when it is deployed    | Yes, for `wrangler publish`      |
+| `preview_id` | The ID of the namespace you wish to bind to the Worker's global scope when it is previewed | Yes, for `wrangler dev` and `wrangler preview` |
 
-Note: Creating your KV Namespaces can be handled using Wrangler's [KV Commands](/tooling/wrangler/kv_commands). 
+Note: Creating your KV Namespaces can be handled using Wrangler's [KV Commands](/tooling/wrangler/kv_commands).
 
 You can also define your `kv_namespaces` using [alternative TOML syntax](https://github.com/toml-lang/toml#user-content-table).
 

--- a/workers-docs/src/content/tooling/wrangler/kv_commands.md
+++ b/workers-docs/src/content/tooling/wrangler/kv_commands.md
@@ -30,12 +30,9 @@ whose title is a concatenation of your Worker's name (from `wrangler.toml`) and 
 
 ```console
 $ wrangler kv:namespace create "MY_KV"
-🌀  Creating namespace with title "worker-MY_KV"
-✨  Success: WorkersKvNamespace {
-    id: "e29b263ab50e42ce9b637fa8370175e8",
-    title: "worker-MY_KV",
-}
-✨  Add the following to your wrangler.toml:
+🌀  Creating namespace with title "my-site-MY_KV"
+✨  Success!
+Add the following to your wrangler.toml:
 kv_namespaces = [
          { binding = "MY_KV", id = "e29b263ab50e42ce9b637fa8370175e8" }
 ]
@@ -99,6 +96,7 @@ Most `kv` commands require you to specify a namespace. A namespace can be specif
     ```sh
     wrangler kv:key get --binding=MY_KV "my key"
     ```
+    - This can be combined with `--preview` flag to interact with a preview namespace instead of a production namespace
 1. With a `--namespace_id`:
     ```sh
     wrangler kv:key get --namespace-id=06779da6940b431db6e566b4846d64db "my key"
@@ -140,20 +138,26 @@ To learn more about environments, check out the [environments documentation](/to
 
 Creates a new namespace.
 
-Takes an optional `--env` [environment](/tooling/wrangler/environments) argument.
+Takes an optional `--env` [environment](/tooling/wrangler/environments) argument and an optional `--preview` argument.
 
 #### Usage
 
 ```console
 $ wrangler kv:namespace create "MY_KV"
 🌀  Creating namespace with title "worker-MY_KV"
-✨  Success: WorkersKvNamespace {
-    id: "e29b263ab50e42ce9b637fa8370175e8",
-    title: "worker-MY_KV",
-}
 ✨  Add the following to your wrangler.toml:
 kv_namespaces = [
          { binding = "MY_KV", id = "e29b263ab50e42ce9b637fa8370175e8" }
+]
+```
+
+```console
+$ wrangler kv:namespace create "MY_KV" --preview
+🌀  Creating namespace with title "my-site-MY_KV_preview"
+✨  Success!
+Add the following to your wrangler.toml:
+kv_namespaces = [
+         { binding = "MY_KV", preview_id = "15137f8edf6c09742227e99b08aaf273" }
 ]
 ```
 
@@ -188,7 +192,7 @@ Deletes a given namespace.
 
 Requires `--binding` or `--namespace-id` argument.
 
-Takes an optional `--env` [environment](/tooling/wrangler/environments) argument.
+Takes an optional `--env` [environment](/tooling/wrangler/environments) argument and an optional `--preview` argument.
 
 #### Usage
 
@@ -199,6 +203,15 @@ yes
 🌀  Deleting namespace f7b02e7fc70443149ac906dd81ec1791
 ✨  Success
 ```
+
+```console
+$ wrangler kv:namespace delete --binding=MY_KV --preview
+Are you sure you want to delete namespace 15137f8edf6c09742227e99b08aaf273? [y/n]
+yes
+🌀  Deleting namespace 15137f8edf6c09742227e99b08aaf273
+✨  Success
+```
+
 </span>
 <span id="kv-key">
 
@@ -212,12 +225,23 @@ Requires `--binding` or `--namespace-id` argument.
 
 Optional params include:
 
+1. `--preview`: Pass this to use your `wrangler.toml`'s `kv_namespaces.preview_id` instead of `kv_namespaces.id`
 1. `--env`: The [environment](/tooling/wrangler/environments) argument.
 1. `--ttl`: Number of seconds for which the entries should be visible before they expire. At least 60. Takes precedence over 'expiration' option.
 1. `--expiration`: Number of seconds since the UNIX epoch, indicating when the key-value pair should expire.
 1. `--path`: Read value from the file at a given path. *This is good for security-sensitive operations, like uploading keys to KV; uploading from a file prevents a key value from being saved in areas like your terminal history.*
 
 #### Usage
+
+```console
+$ wrangler kv:key put --binding=MY_KV "key" "value"
+✨  Success
+```
+
+```console
+$ wrangler kv:key put --binding=MY_KV --preview "key" "value"
+✨  Success
+```
 
 ```console
 $ wrangler kv:key put --binding=MY_KV "key" "value" --ttl=10000
@@ -228,6 +252,7 @@ $ wrangler kv:key put --binding=MY_KV "key" "value" --ttl=10000
 $ wrangler kv:key put --binding=MY_KV "key" value.txt --path
 ✨  Success
 ```
+
 </span>
 <span id="kv-list">
 
@@ -267,7 +292,10 @@ Reads a single value by key from the given namespace.
 
 Requires `--binding` or `--namespace-id` argument.
 
-Takes an optional `--env` [environment](/tooling/wrangler/environments) argument.
+Optional params include:
+
+1. `--preview`: Pass this to use your `wrangler.toml`'s `kv_namespaces.preview_id` instead of `kv_namespaces.id`
+1. `--env`: The [environment](/tooling/wrangler/environments) argument.
 
 #### Usage
 
@@ -282,7 +310,10 @@ Removes a single key value pair from the given namespace.
 
 Requires `--binding` or `--namespace-id` argument.
 
-Takes an optional `--env` [environment](/tooling/wrangler/environments) argument.
+Optional params include:
+
+1. `--preview`: Pass this to use your `wrangler.toml`'s `kv_namespaces.preview_id` instead of `kv_namespaces.id`
+1. `--env`: The [environment](/tooling/wrangler/environments) argument.
 
 #### Usage
 
@@ -327,7 +358,10 @@ The schema below is the full schema for key-value entries uploaded via the bulk 
 
 If both `expiration` and `expiration_ttl` are specified for a given key, the API will prefer `expiration_ttl`.
 
-The `put` command also takes an optional `--env` [environment](/tooling/wrangler/environments) argument.
+Optional params include:
+
+1. `--preview`: Pass this to use your `wrangler.toml`'s `kv_namespaces.preview_id` instead of `kv_namespaces.id`
+1. `--env`: The [environment](/tooling/wrangler/environments) argument.
 
 #### Usage
 
@@ -356,7 +390,10 @@ Takes as an argument a JSON file with a list of key-value pairs to delete (see J
 ]
 ```
 
-The `delete` command also takes an optional `--env` [environment](/tooling/wrangler/environments) argument.
+Optional params include:
+
+1. `--preview`: Pass this to use your `wrangler.toml`'s `kv_namespaces.preview_id` instead of `kv_namespaces.id`
+1. `--env`: The [environment](/tooling/wrangler/environments) argument.
 
 #### Usage
 


### PR DESCRIPTION
in place of #904

> for 1.10.0 release

each of these commits are actually separated out kinda nice for once if you want to review commit by commit