### PR TITLE
answer the pricing for expiring keys and other actions

### DIFF
--- a/workers-docs/src/content/about/pricing.md
+++ b/workers-docs/src/content/about/pricing.md
@@ -26,6 +26,8 @@ Enabling Workers KV requires the Unlimited plan.
 | Included                        | 1 GB         | 10 million        | 1 million         | 1 million         | 1 million         |
 | Price beyond the included quota | $0.50 per GB | $0.50 per million | $5.00 per million | $5.00 per million | $5.00 per million |
 
+Usage of all other features of Worker KV do not affect pricing.
+
 ## Same features 
 
   Script size, number of scripts, subrequests, and available memory are not affected by plan type.


### PR DESCRIPTION
This PR was discussed previously #469, then the docs changed before the merge. Now this question has resurfaced in the [Community](https://community.cloudflare.com/t/do-we-get-billed-for-auto-expired-keys-on-workers-kv/183429).

I added the text back:
> Usage of all other features of Worker KV do not affect pricing.