### PR TITLE
Fixes Hugo-style `ref` links in `/archive` docs

### DIFF
--- a/workers-docs/src/content/archive/faq/_index.md
+++ b/workers-docs/src/content/archive/faq/_index.md
@@ -33,7 +33,7 @@ An individual Worker script may consume up to:
 - 5-50 milliseconds CPU time per request, depending on Cloudflare Plan
 - 128MB memory at any given time
 
-For more information, see [Resource Limits]({{< ref "archive/writing-workers/resource-limits.md" >}}).
+For more information, see [Resource Limits](/workers/archive/writing-workers/resource-limits).
 
 ### Why JavaScript? Isn’t it slow?
 
@@ -67,7 +67,7 @@ your origin or alternative data storage tools as needed.
 ### How should I load data in my Worker?
 
 We don’t currently provide an API for loading data in Workers. There are, however,
-[several techniques]({{< ref "archive/writing-workers/storing-data.md" >}}) for loading data
+[several techniques](/workers/archive/writing-workers/storing-data) for loading data
 in a Worker.
 
 ### Will my Worker’s response be cached by Cloudflare?
@@ -85,7 +85,7 @@ message has been received and is available in memory.
 
 If your Worker script must analyze or transform a request/response body, then you must
 buffer at least some portion of the body. For very large bodies, you may wish to use
-the [TransformStream API]({{< ref "archive/recipes/streaming-responses.md" >}}) to minimize
+the [TransformStream API](/workers/archive/recipes/streaming-responses) to minimize
 your memory footprint and time-to-first-byte.
 
 ### What headers are available in my Worker?
@@ -111,7 +111,7 @@ using an external system.
 Use a Map object: `console.log(new Map(request.headers))`.
 
 For a deeper explanation of why this works, and other header stringification options,
-read our section on [console logging headers]({{< ref "archive/writing-workers/debugging-tips.md#console-logging-headers" >}}).
+read our section on [console logging headers](/workers/archive/writing-workers/debugging-tips/#console-logging-headers).
 
 ### My Worker is 500ing, how can I find out why?
 

--- a/workers-docs/src/content/archive/recipes/streaming-responses.md
+++ b/workers-docs/src/content/archive/recipes/streaming-responses.md
@@ -71,7 +71,7 @@ a prefix or a suffix to the body, or to process it in some way.
 
 ## Aggregate and stream multiple requests
 
-This is similar to our [Aggregating Multiple Requests]({{< ref "archive/recipes/aggregating-multiple-requests.md" >}})
+This is similar to our [Aggregating Multiple Requests](/workers/archive/recipes/aggregating-multiple-requests)
 recipe, but this time we'll start writing our response as soon as we've
 verified that every subrequest succeeded --- no need to wait for the actual
 response bodies.

--- a/workers-docs/src/content/archive/reference/_index.md
+++ b/workers-docs/src/content/archive/reference/_index.md
@@ -18,8 +18,8 @@ you need.
 
 | API                                                                                      | Support                                                                                                                                                                                                                                                                                                                                             |
 | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [ECMAScript Builtins](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference) | Everything supported by current Google Chrome stable release. <br/> [WebAssembly]({{< ref "/tooling/api/bindings" >}}) <br/> `eval()` and `new Function()` are disallowed for security reasons. <br/> `Date.now()` returns the time of last I/O; it does not advance during code execution.                             |
-| [Service Worker API](https://developer.mozilla.org/docs/Web/API/Service_Worker_API)      | `"fetch"` event <br/> [Cache API]({{< ref "archive/reference/cache-api.md" >}})[^no-playground]                                                                                                                                                                                                                                                      |
+| [ECMAScript Builtins](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference) | Everything supported by current Google Chrome stable release. <br/> [WebAssembly](/workers/tooling/api/bindings) <br/> `eval()` and `new Function()` are disallowed for security reasons. <br/> `Date.now()` returns the time of last I/O; it does not advance during code execution.                             |
+| [Service Worker API](https://developer.mozilla.org/docs/Web/API/Service_Worker_API)      | `"fetch"` event <br/> [Cache API](/workers/reference/cache-api)[^no-playground]                                                                                                                                                                                                                                                      |
 | [Web Global APIs](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope)  | Base64 utility methods <br/> Timers[^request-ctx]                                                                                                                                                                                                                                                                                                    |
 | [Encoding API](https://developer.mozilla.org/docs/Web/API/Encoding_API)                  | UTF-8                                                                                                                                                                                                                                                                                                                                               |
 | [URL API](https://developer.mozilla.org/docs/Web/API/URL)                                | http://, https:// schemes                                                                                                                                                                                                                                                                                                                           |
@@ -33,15 +33,13 @@ you need.
     settled. Any attempt to use such APIs during script startup will throw an exception.
 
     For example:
-
     ```js
-const promise = fetch("https://example.com/")       // ERROR
+    const promise = fetch("https://example.com/")       // ERROR
 
-addEventListener("fetch", event => {
-  event.respondWith(fetch("https://example.com/"))  // OK
-})
-```
-
+    addEventListener("fetch", event => {
+      event.respondWith(fetch("https://example.com/"))  // OK
+    })
+    ```
     This code snippet **will throw** during script startup, and the `"fetch"` event
     listener will never be registered.
 

--- a/workers-docs/src/content/archive/writing-workers/resource-limits.md
+++ b/workers-docs/src/content/archive/writing-workers/resource-limits.md
@@ -53,7 +53,7 @@ you can persist data between requests on an individual node, but note that nodes
 evicted from memory.
 
 If you are concerned about memory usage, the solution is often to stream your responses
-(potentially using the [TransformStream API]({{< ref "archive/recipes/streaming-responses.md" >}}))
+(potentially using the [TransformStream API](/workers/archive/recipes/streaming-responses)
 rather than loading an entire response into memory.
 
 ## Requests

--- a/workers-docs/src/content/archive/writing-workers/storing-data.md
+++ b/workers-docs/src/content/archive/writing-workers/storing-data.md
@@ -53,7 +53,7 @@ You can, for example, load data from your origin and store it in a global variab
 the next time your Worker is executed on that node (if it hasn't been stopped and started in between).
 
 Keep in mind that the memory available for such caching is limited. Each running instance of your
-Worker [can use up to 128MB of RAM]({{< ref "archive/writing-workers/resource-limits.md" >}})), including
+Worker [can use up to 128MB of RAM](/workers/archive/writing-workers/resource-limits)), including
 space used to store your code, local variables used during execution, etc. If your Worker uses too
 much memory, it will be killed and restarted, possibly disrupting users. Even when it is within the
 limits, a Worker that is running close to its limits may slow down due to increased garbage


### PR DESCRIPTION
A number of pages in the /archive section have broken relative links of
the form `[Resource Limits]({{< ref
"archive/writing-workers/resource-limits.md" >}})`. That appears to be a
Hugo thing: https://gohugo.io/content-management/cross-references/ .
This change replaces all such links.

Also, updated the formatting on the code block on the /archive/reference
page while I was there, because it was broken.

I tested all the links by loading them in the local dev environment and clicking on them.