### PR TITLE
Fix Rust style guide heading

### DIFF
--- a/workers-docs/src/content/templates/style/rust.md
+++ b/workers-docs/src/content/templates/style/rust.md
@@ -1,4 +1,4 @@
-#Rust Style Guide
+# Rust Style Guide
 
 If you are using Wasm and write in Rust, your template should adhere to rustfmt and clippy.
 


### PR DESCRIPTION
When the docs are viewed on GitHub the heading is broken.

<img width="1093" alt="Screen Shot 2020-06-28 at 8 53 41 am" src="https://user-images.githubusercontent.com/418747/85933708-9698ae00-b91d-11ea-9014-3c2faef3ad5a.png">
