### PR TITLE
Remove inappropriate syntax highlighting

### DIFF
--- a/workers-docs/src/content/reference/apis/environment-variables.md
+++ b/workers-docs/src/content/reference/apis/environment-variables.md
@@ -25,7 +25,7 @@ In the below example, we set the secret `SECRET` using `wrangler secret`, and th
 
 Creating the secret using [`wrangler secret`](/tooling/wrangler/secrets):
 
-```bash
+```
 wrangler secret put SECRET
 Enter the secret text you'd like assigned to the variable name on the script named my-worker-ENVIRONMENT_NAME: mysekret
 ```


### PR DESCRIPTION
Bash syntax highlighting adds nothing to this code block, but causes errant coloring post-apostrophe