### PR TITLE
Fix spelling

### DIFF
--- a/workers-docs/src/content/reference/apis/fetch.md
+++ b/workers-docs/src/content/reference/apis/fetch.md
@@ -5,7 +5,7 @@ weight: 2
 
 ## Overview
 
-The [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) provides an interface for asyncronously fetching resources via HTTP requests inside of a Worker.
+The [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) provides an interface for asynchronously fetching resources via HTTP requests inside of a Worker.
 
 ## Global
 


### PR DESCRIPTION
Got the spelling from MDN 

https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous